### PR TITLE
Replacing double dashes with a single en-dash

### DIFF
--- a/src/main/java/no/dusken/momus/service/drive/GoogleDocsTextConverter.java
+++ b/src/main/java/no/dusken/momus/service/drive/GoogleDocsTextConverter.java
@@ -43,7 +43,7 @@ public class GoogleDocsTextConverter {
 
     ArrayList<Pattern> hTags = initTitles();
 
-
+    Pattern dashes = Pattern.compile("--");
     Pattern inlineComments = Pattern.compile("<sup>.*?</sup>");
     Pattern spaces = Pattern.compile("&nbsp;");
     Pattern comments = Pattern.compile("<div><p>.*?</p></div>");
@@ -78,6 +78,7 @@ public class GoogleDocsTextConverter {
         out = removeEmptyPTags(out);
         out = unescapeHtml(out);
         out = replaceTitles(out);
+        out = replaceDashes(out);
 
         return out;
     }
@@ -223,6 +224,14 @@ public class GoogleDocsTextConverter {
         out = m.replaceAll(" ");
 
         return out;
+    }
+
+    /*
+     * Replaces "--" with an en-dash
+     */
+    private String replaceDashes(String in) {
+        Matcher m = dashes.matcher(in);
+        return m.replaceAll("–");
     }
 
     /**

--- a/src/main/java/no/dusken/momus/service/indesign/IndesignGenerator.java
+++ b/src/main/java/no/dusken/momus/service/indesign/IndesignGenerator.java
@@ -54,7 +54,8 @@ public class IndesignGenerator {
         replacements.put("<br></", "</"); // ignore line breaks at end of tags
         replacements.put("<br>", "<0x000A>"); // in-line line-breaks
         replacements.put("–", "<0x2014>"); // m-dash?
-        replacements.put("—", "<0x2014>"); // m-dash
+        //replacements.put("—", "<0x2014>"); // m-dash
+        replacements.put("—", "<0x2013>");
 
         // change paragraphs and stuff to InDesign equivalent
         replacements.put("<h1>", "<ParaStyle:Tittel>");

--- a/src/main/java/no/dusken/momus/service/indesign/IndesignGenerator.java
+++ b/src/main/java/no/dusken/momus/service/indesign/IndesignGenerator.java
@@ -53,9 +53,8 @@ public class IndesignGenerator {
 
         replacements.put("<br></", "</"); // ignore line breaks at end of tags
         replacements.put("<br>", "<0x000A>"); // in-line line-breaks
-        replacements.put("–", "<0x2014>"); // m-dash?
-        //replacements.put("—", "<0x2014>"); // m-dash
-        replacements.put("—", "<0x2013>");
+        replacements.put("–", "<0x2013>"); // m-dash?
+        replacements.put("—", "<0x2014>"); // m-dash
 
         // change paragraphs and stuff to InDesign equivalent
         replacements.put("<h1>", "<ParaStyle:Tittel>");


### PR DESCRIPTION
when importing from google docs