### PR TITLE
Add roles and support for authorization

### DIFF
--- a/src/main/java/no/dusken/momus/authorization/AdminAuthorization.java
+++ b/src/main/java/no/dusken/momus/authorization/AdminAuthorization.java
@@ -1,0 +1,13 @@
+package no.dusken.momus.authorization;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("hasAnyRole(T(no.dusken.momus.authorization.Role).ROLE_ADMIN)")
+public @interface AdminAuthorization {
+}

--- a/src/main/java/no/dusken/momus/authorization/IllustratorAuthorization.java
+++ b/src/main/java/no/dusken/momus/authorization/IllustratorAuthorization.java
@@ -1,0 +1,15 @@
+package no.dusken.momus.authorization;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("hasAnyRole(" +
+        "T(no.dusken.momus.authorization.Role).ROLE_ILLUSTRATOR, " +
+        "T(no.dusken.momus.authorization.Role).ROLE_ADMIN)")
+public @interface IllustratorAuthorization {
+}

--- a/src/main/java/no/dusken/momus/authorization/Role.java
+++ b/src/main/java/no/dusken/momus/authorization/Role.java
@@ -1,0 +1,14 @@
+package no.dusken.momus.authorization;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import java.io.Serializable;
+
+public enum Role implements Serializable, GrantedAuthority {
+    ROLE_USER, ROLE_ADMIN;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
+}

--- a/src/main/java/no/dusken/momus/authorization/Role.java
+++ b/src/main/java/no/dusken/momus/authorization/Role.java
@@ -5,7 +5,7 @@ import org.springframework.security.core.GrantedAuthority;
 import java.io.Serializable;
 
 public enum Role implements Serializable, GrantedAuthority {
-    ROLE_USER, ROLE_ADMIN;
+    ROLE_USER, ROLE_ADMIN, ROLE_ILLUSTRATOR;
 
     @Override
     public String getAuthority() {

--- a/src/main/java/no/dusken/momus/authorization/UserAuthorization.java
+++ b/src/main/java/no/dusken/momus/authorization/UserAuthorization.java
@@ -1,0 +1,13 @@
+package no.dusken.momus.authorization;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("hasRole(T(no.dusken.momus.authorization.Role).ROLE_USER)")
+public @interface UserAuthorization {
+}

--- a/src/main/java/no/dusken/momus/ldap/LDAPAttributes.java
+++ b/src/main/java/no/dusken/momus/ldap/LDAPAttributes.java
@@ -2,6 +2,7 @@ package no.dusken.momus.ldap;
 
 import org.w3c.dom.Attr;
 
+import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
@@ -9,8 +10,7 @@ import javax.sql.rowset.serial.SerialBlob;
 import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.UUID;
+import java.util.*;
 
 public class LDAPAttributes {
     private static final String usernameAttribute = "sAMAccountName";
@@ -20,6 +20,7 @@ public class LDAPAttributes {
     private static final String firstNameAttribute = "givenName";
     private static final String lastNameAttribute = "sn";
     private static final String photoAttribute = "thumbnailPhoto";
+    private static final String groupAttribute = "memberOf";
     private static final String[] nameAttributes = {"displayName", "name", "cn"};
 
     public static String getUsername(Attributes attributes) throws NamingException {
@@ -61,6 +62,18 @@ public class LDAPAttributes {
                 .filter(s -> !s.trim().isEmpty())
                 .findFirst()
                 .orElse(String.format("%s (mangler visningsnavn)", getUsername(attributes)));
+    }
+
+    public static Collection<String> getGroups(Attributes attributes) throws NamingException {
+        Attribute groupAttributes = attributes.get(groupAttribute);
+        Collection<String> groupSet = new HashSet<>();
+        if (groupAttributes != null) {
+            NamingEnumeration<?> groups = groupAttributes.getAll();
+            while (groups.hasMore()) {
+                groupSet.add((String) groups.next());
+            }
+        }
+        return groupSet;
     }
 
     private static String getAttribute(Attributes attributes, String... keys) throws NamingException {

--- a/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
+++ b/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
@@ -82,6 +82,7 @@ public class LdapSyncer {
     @PostConstruct
     public void startUp(){
         groupToRole.put(env.getProperty("roles.admin"), Role.ROLE_ADMIN);
+        groupToRole.put(env.getProperty("roles.illustrator"), Role.ROLE_ILLUSTRATOR);
         sync();
     }
 

--- a/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
+++ b/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
@@ -81,7 +81,7 @@ public class LdapSyncer {
 
     @PostConstruct
     public void startUp(){
-        groupToRole.put(env.getProperty("roles.momus_admin"), Role.ROLE_ADMIN);
+        groupToRole.put(env.getProperty("roles.admin"), Role.ROLE_ADMIN);
         sync();
     }
 

--- a/src/main/java/no/dusken/momus/ldap/PersonMapper.java
+++ b/src/main/java/no/dusken/momus/ldap/PersonMapper.java
@@ -1,5 +1,6 @@
 package no.dusken.momus.ldap;
 
+import no.dusken.momus.authorization.Role;
 import no.dusken.momus.model.Person;
 import no.dusken.momus.service.repository.PersonRepository;
 import org.springframework.ldap.core.AttributesMapper;
@@ -8,17 +9,20 @@ import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
 import java.sql.Blob;
 import java.sql.SQLException;
-import java.util.UUID;
+import java.util.*;
 
 public class PersonMapper implements AttributesMapper<Person> {
     private PersonRepository personRepository;
     private boolean active;
     private long lastId;
 
-    public PersonMapper(PersonRepository personRepository, boolean active) {
+    private Map<String, Role> groupToRole;
+
+    public PersonMapper(PersonRepository personRepository, boolean active, Map<String, Role> groupToRole) {
         this.personRepository = personRepository;
         this.active = active;
         this.lastId = 0L;
+        this.groupToRole = groupToRole;
     }
 
     @Override
@@ -34,6 +38,7 @@ public class PersonMapper implements AttributesMapper<Person> {
         String phoneNumber = LDAPAttributes.getPhoneNumber(attributes);
         UUID guid = LDAPAttributes.getGuid(attributes);
         Blob photo = LDAPAttributes.getPhoto(attributes);
+        Collection<String> groups = LDAPAttributes.getGroups(attributes);
 
         Person person = getPersonIfExists(guid, username);
 
@@ -50,6 +55,14 @@ public class PersonMapper implements AttributesMapper<Person> {
         if(photo != null) {
             person.setPhoto(photo);
         }
+
+        Collection<Role> roles = new HashSet<>();
+        roles.add(Role.ROLE_USER);
+        for (String accessGroup: groupToRole.keySet())
+            if (groups.contains(accessGroup)) {
+                roles.add(groupToRole.get(accessGroup));
+        }
+        person.setRoles(roles);
 
         return person;
     }

--- a/src/main/java/no/dusken/momus/model/Person.java
+++ b/src/main/java/no/dusken/momus/model/Person.java
@@ -17,14 +17,19 @@
 package no.dusken.momus.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import no.dusken.momus.authorization.Role;
 import org.hibernate.annotations.Type;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 import java.sql.Blob;
+import java.util.Collection;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
-public class Person {
+public class Person implements UserDetails {
 
     @Id
     private Long id;
@@ -49,6 +54,10 @@ public class Person {
     @JsonIgnore
     @Lob
     private Blob photo;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Collection<Role> roles;
 
     public Person() {
     }
@@ -134,6 +143,57 @@ public class Person {
     public void setPhoto(Blob photo) {
         this.photo = photo;
     }
+
+    public Collection<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Collection<Role> roles) {
+        this.roles = roles;
+    }
+
+    /*
+    The following methods is to implement UserDetails,
+    so that Spring can get a persons roles.
+     */
+
+    @JsonIgnore
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @JsonIgnore
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @JsonIgnore
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @JsonIgnore
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @JsonIgnore
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    /* End UserDetails */
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/resources/db-changelog.xml
+++ b/src/main/resources/db-changelog.xml
@@ -718,4 +718,21 @@
             <column name="photo" type="BLOB" />
         </addColumn>
     </changeSet>
+
+    <changeSet id="42_adduserroles" author="Eirik">
+        <createTable tableName="person_roles">
+            <column name="person_id" type="BIGINT">
+                <constraints nullable="false" />
+            </column>
+            <column name="roles" type="VARCHAR(255)" />
+        </createTable>
+        <addForeignKeyConstraint
+                baseTableName="person_roles" baseColumnNames="person_id"
+                constraintName="FK_role_person"
+                referencedTableName="person"
+                referencedColumnNames="id"
+                onDelete="CASCADE"
+                onUpdate="CASCADE"
+        />
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/momus.properties
+++ b/src/main/resources/momus.properties
@@ -63,3 +63,6 @@ saml.entityid=momusdev.smint.no
 saml.serverurl=localhost:8080
 saml.scheme=http
 saml.port=8080
+
+# Authorization
+roles.momus_admin=group-DN

--- a/src/main/webapp/app/js/services/httpInterceptor.js
+++ b/src/main/webapp/app/js/services/httpInterceptor.js
@@ -42,6 +42,11 @@ angular.module('momusApp.services').
                     reloadOnAlertClose = true;
                 }
 
+                else if (response.status === 403) {
+                    errorMessage = '<p>Du har ikke rettigheter til å gjøre dette</p>' +
+                        '<p>Du prøvde å aksessere ' + response.config.url + '</p>';
+                }
+
                 else if (response.data.error) {
                     errorMessage = response.data.error;
                     showExtras = true;


### PR DESCRIPTION
Roles are assigned to users based on LDAP groups.
To add a new role:
    Add the role to the Role enum.
    Add the group DN to local.properties, eg.
     roles.admin=CN=admin,OU=groups,DC=company,DC=com.
    Add mapping from DN to Role in Ldapsyncer.groupToRole, see code for
     an example.

Authorization on an endpoint is done byannotating it using @Preauthorize in
combination with hasRole(s). The AdminAuthorization and UserAuthorization
annotations have been written to ease annotation.