### PR TITLE
Replace Date with ZonedDateTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <spring-ldap.version>2.0.2.RELEASE</spring-ldap.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <jackson-datatype-hibernate5.version>2.9.0</jackson-datatype-hibernate5.version>
+        <jackson-datatype-jsr310.version>2.9.4</jackson-datatype-jsr310.version>
         <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
         <liquibase.version>3.5.3</liquibase.version>
         <google-drive.version>v2-rev277-1.22.0</google-drive.version>
@@ -205,6 +206,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
             <version>${jackson-datatype-hibernate5.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson-datatype-jsr310.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/no/dusken/momus/controller/DevController.java
+++ b/src/main/java/no/dusken/momus/controller/DevController.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 /**
@@ -94,12 +96,12 @@ public class DevController {
 
         Publication p1 = new Publication();
         p1.setName("UD #1-2018");
-        p1.setReleaseDate(new GregorianCalendar(2018, Calendar.JANUARY, 20).getTime());
+        p1.setReleaseDate(ZonedDateTime.of(2018, 1, 20, 0, 0, 0, 0, ZoneId.systemDefault()));
         p1 = publicationService.savePublication(p1, 50);
 
         Publication p2 = new Publication();
         p2.setName("UD #2-2018");
-        p2.setReleaseDate(new GregorianCalendar(2018, Calendar.FEBRUARY, 10).getTime());
+        p1.setReleaseDate(ZonedDateTime.of(2018, 2, 10, 0, 0, 0, 0, ZoneId.systemDefault()));
         p2 = publicationService.savePublication(p2, 50);
 
         Article a1 = new Article();

--- a/src/main/java/no/dusken/momus/controller/PublicationController.java
+++ b/src/main/java/no/dusken/momus/controller/PublicationController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 @RestController
@@ -90,7 +91,7 @@ public class PublicationController {
 
     @GetMapping("/active")
     public @ResponseBody Publication getActivePublication(){
-        Publication active = publicationService.getActivePublication(new Date());
+        Publication active = publicationService.getActivePublication(ZonedDateTime.now());
         if(active == null) {
             throw new RestException("No active publication found", HttpServletResponse.SC_NOT_FOUND);
         }

--- a/src/main/java/no/dusken/momus/mapper/HibernateAwareObjectMapper.java
+++ b/src/main/java/no/dusken/momus/mapper/HibernateAwareObjectMapper.java
@@ -16,9 +16,12 @@
 
 package no.dusken.momus.mapper;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * An ObjectMapper that registers a HibernateModule, so a JSON serialization
@@ -32,5 +35,10 @@ public class HibernateAwareObjectMapper extends ObjectMapper {
         // converts lastName to last_name and the other way
         setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         registerModule(new Hibernate5Module());
+
+        // frontend expects times/dates as milliseconds since epoch
+        registerModule(new JavaTimeModule());
+        disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+        disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
     }
 }

--- a/src/main/java/no/dusken/momus/model/Article.java
+++ b/src/main/java/no/dusken/momus/model/Article.java
@@ -23,8 +23,9 @@ import no.dusken.momus.service.ArticleService;
 
 import javax.persistence.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Set;
 
 @Entity
@@ -68,8 +69,7 @@ public class Article{
     @Fetch(FetchMode.SUBSELECT)
     private Set<Person> photographers;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastUpdated;
+    private ZonedDateTime lastUpdated;
 
     private String photoStatus;
 
@@ -170,11 +170,11 @@ public class Article{
         this.photographers = photographers;
     }
 
-    public Date getLastUpdated() {
+    public ZonedDateTime getLastUpdated() {
         return lastUpdated;
     }
 
-    public void setLastUpdated(Date lastUpdated) {
+    public void setLastUpdated(ZonedDateTime lastUpdated) {
         this.lastUpdated = lastUpdated;
     }
 

--- a/src/main/java/no/dusken/momus/model/ArticleRevision.java
+++ b/src/main/java/no/dusken/momus/model/ArticleRevision.java
@@ -17,7 +17,7 @@
 package no.dusken.momus.model;
 
 import javax.persistence.*;
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 @Entity
 public class ArticleRevision {
@@ -34,8 +34,7 @@ public class ArticleRevision {
     @ManyToOne
     private ArticleStatus status;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date savedDate;
+    private ZonedDateTime savedDate;
 
     private boolean statusChanged;
 
@@ -73,11 +72,11 @@ public class ArticleRevision {
         this.status = status;
     }
 
-    public Date getSavedDate() {
+    public ZonedDateTime getSavedDate() {
         return savedDate;
     }
 
-    public void setSavedDate(Date savedDate) {
+    public void setSavedDate(ZonedDateTime savedDate) {
         this.savedDate = savedDate;
     }
 

--- a/src/main/java/no/dusken/momus/model/Publication.java
+++ b/src/main/java/no/dusken/momus/model/Publication.java
@@ -18,7 +18,7 @@ package no.dusken.momus.model;
 
 import javax.persistence.*;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -31,8 +31,7 @@ public class Publication {
 
     private String name;
 
-    @Temporal(TemporalType.DATE)
-    private Date releaseDate;
+    private ZonedDateTime releaseDate;
 
     @OneToMany(mappedBy = "publication", fetch = FetchType.LAZY)
     private Set<Article> articles;
@@ -61,11 +60,11 @@ public class Publication {
         this.name = name;
     }
 
-    public Date getReleaseDate() {
+    public ZonedDateTime getReleaseDate() {
         return releaseDate;
     }
 
-    public void setReleaseDate(Date releaseDate) {
+    public void setReleaseDate(ZonedDateTime releaseDate) {
         this.releaseDate = releaseDate;
     }
 

--- a/src/main/java/no/dusken/momus/model/websocket/Message.java
+++ b/src/main/java/no/dusken/momus/model/websocket/Message.java
@@ -1,6 +1,7 @@
 package no.dusken.momus.model.websocket;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
+
 import no.dusken.momus.model.websocket.Action;
 
 public class Message {
@@ -8,7 +9,7 @@ public class Message {
 	private Long articleId;
 	private Action action;
 	private String editedField;
-    private Date date;
+	private ZonedDateTime date;
 
 	public Action getAction() {
 		return this.action;
@@ -18,7 +19,7 @@ public class Message {
 		this.action = action;
 	}
 
-	public Date getDate() {
+	public ZonedDateTime getDate() {
 		return date;
 	}
 

--- a/src/main/java/no/dusken/momus/model/websocket/OutputMessage.java
+++ b/src/main/java/no/dusken/momus/model/websocket/OutputMessage.java
@@ -1,15 +1,15 @@
 package no.dusken.momus.model.websocket;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 public class OutputMessage {
 	private Long pageId;
 	private Long articleId;
 	private Action action;
 	private String editedField;
-    private Date date;
+	private ZonedDateTime date;
 
-    public OutputMessage(Long pageId, Long articleId, Action action, String editedField, Date date){
+    public OutputMessage(Long pageId, Long articleId, Action action, String editedField, ZonedDateTime date){
         this.pageId = pageId;
         this.articleId = articleId;
 		this.action = action;
@@ -25,7 +25,7 @@ public class OutputMessage {
 		this.action = action;
 	}
 
-	public Date getDate() {
+	public ZonedDateTime getDate() {
 		return date;
 	}
 

--- a/src/main/java/no/dusken/momus/service/ArticleService.java
+++ b/src/main/java/no/dusken/momus/service/ArticleService.java
@@ -36,8 +36,9 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -100,7 +101,7 @@ public class ArticleService {
     }
 
     public Article updateArticle(Article article) {
-        article.setLastUpdated(new Date());
+        article.setLastUpdated(ZonedDateTime.now());
         logger.info("Article with id {} updated, data: {}", article.getId(), article.dump());
         return articleRepository.saveAndFlush(article);
     }
@@ -200,7 +201,7 @@ public class ArticleService {
      */
     public ArticleRevision createRevision(Article article) {
 
-        Date saveDate = new Date();
+        ZonedDateTime saveDate = ZonedDateTime.now();
         ArticleRevision revision = getLastRevision(article);
 
         boolean isStatusChanged = 
@@ -217,7 +218,7 @@ public class ArticleService {
             revision = new ArticleRevision();
         }
         
-        revision.setSavedDate(new Date());
+        revision.setSavedDate(ZonedDateTime.now());
         revision.setStatusChanged(isStatusChanged);
         revision.setContent(article.getContent());
         revision.setArticle(article);
@@ -228,9 +229,8 @@ public class ArticleService {
         return revision;
     }
 
-    private boolean isRevisionTooOld(ArticleRevision revision, Date date) {
-        long timeDiff = date.getTime() - revision.getSavedDate().getTime();
-        return timeDiff > 3 * 60 * 1000;
+    private boolean isRevisionTooOld(ArticleRevision revision, ZonedDateTime date) {
+        return Duration.between(revision.getSavedDate(), date).toMinutes() > 3;
     }
 
     private ArticleRevision getLastRevision(Article article) {

--- a/src/main/java/no/dusken/momus/service/PublicationService.java
+++ b/src/main/java/no/dusken/momus/service/PublicationService.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
 import java.util.*;
 
 @Service
@@ -113,7 +114,7 @@ public class PublicationService {
      *
      * @return Returns the oldest publication that has not been released yet at the time of the date parameter
      */
-    public Publication getActivePublication(Date date){
+    public Publication getActivePublication(ZonedDateTime date){
         List<Publication> publications = publicationRepository.findAllByOrderByReleaseDateDesc();
 
         if(publications.isEmpty()) return null;
@@ -122,7 +123,7 @@ public class PublicationService {
 
         Publication active = publications.get(0);
         for(Publication p : publications.subList(1,publications.size())){
-            if(p.getReleaseDate().before(date)){
+            if(p.getReleaseDate().isBefore(date)){
                 return active;
             }else{
                 active = p;

--- a/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
@@ -259,28 +260,28 @@ public class ArticleServiceTest extends AbstractServiceTest {
         when(articleRevisionRepository.save(any(ArticleRevision.class))).then(returnsFirstArg());
 
         // Test too old previous revision creates new
-        Calendar c = Calendar.getInstance();
-        c.add(Calendar.DATE, -1);
+        ZonedDateTime c = ZonedDateTime.now();
+        c = c.minusDays(1);
 
-        article1Revision1.setSavedDate(c.getTime());
+        article1Revision1.setSavedDate(c);
         article1Revision1.setStatusChanged(false);
 
         assertTrue(articleServiceSpy.createRevision(article1) != article1Revision1);
 
         // Test young previous revision but changed status creates new
-        c = Calendar.getInstance();
-        c.add(Calendar.HOUR, -1);
+        c = ZonedDateTime.now();
+        c = c.minusHours(1);
 
-        article1Revision1.setSavedDate(c.getTime());
+        article1Revision1.setSavedDate(c);
         article1Revision1.setStatusChanged(true);
 
         assertTrue(articleServiceSpy.createRevision(article1) != article1Revision1);
 
         // Test young previous revision and not changed status reuses old
-        c = Calendar.getInstance();
-        c.add(Calendar.MINUTE, -1);
+        c = ZonedDateTime.now();
+        c = c.minusMinutes(1);
 
-        article1Revision1.setSavedDate(c.getTime());
+        article1Revision1.setSavedDate(c);
         article1Revision1.setStatusChanged(false);
 
         assertTrue(articleServiceSpy.createRevision(article1) == article1Revision1);

--- a/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -98,17 +100,17 @@ public class PublicationServiceTest extends AbstractServiceTest {
     }
 
     /**
-     * Method: {@link PublicationService#getActivePublication(Date)}
+     * Method: {@link PublicationService#getActivePublication(ZonedDateTime)}
      */
     @Test
     public void testGetActivePublication() {
-        publication1.setReleaseDate(new Date(2017, 8, 10)); //Old
-        publication2.setReleaseDate(new Date(2017, 8, 12));
-        publication3.setReleaseDate(new Date(2017, 8, 14));
+        publication1.setReleaseDate(ZonedDateTime.of(2017, 8, 10, 0, 0, 0, 0, ZoneId.systemDefault())); //Old
+        publication2.setReleaseDate(ZonedDateTime.of(2017, 8, 12, 0, 0, 0, 0, ZoneId.systemDefault()));
+        publication3.setReleaseDate(ZonedDateTime.of(2017, 8, 14, 0, 0, 0, 0, ZoneId.systemDefault()));
 
         doReturn(Arrays.asList(publication2, publication2, publication1)).when(publicationRepository).findAllByOrderByReleaseDateDesc();
 
-        assertEquals(publication2, publicationService.getActivePublication(new Date(2017, 8, 11)));
+        assertEquals(publication2, publicationService.getActivePublication(ZonedDateTime.of(2017, 8, 11, 0, 0, 0, 0, ZoneId.systemDefault())));
     }
 
     @Test


### PR DESCRIPTION
Date is deprecated.
ZonedDateTime was chosen since the frontend operates
on epoch time, in millisecond format.
jsr310 is needed for object mapping of ZonedDateTime.