### PR TITLE
MOM-264 update spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,10 @@
         <java.version>1.8</java.version>
 
         <lombok.version>1.18.2</lombok.version>
-        <spring.version>4.3.20.RELEASE</spring.version>
-        <spring-data.version>1.11.16.RELEASE</spring-data.version>
-        <spring-ldap.version>2.0.2.RELEASE</spring-ldap.version>
-        <spring-security.version>4.2.9.RELEASE</spring-security.version>
+        <spring.version>5.1.2.RELEASE</spring.version>
+        <spring-data.version>2.1.2.RELEASE</spring-data.version>
+        <spring-ldap.version>2.3.2.RELEASE</spring-ldap.version>
+        <spring-security.version>5.1.1.RELEASE</spring-security.version>
         <spring-security-saml2.version>1.0.3.RELEASE</spring-security-saml2.version>
         <hibernate.version>5.3.7.Final</hibernate.version>
         <jackson.version>2.9.7</jackson.version>

--- a/src/main/java/no/dusken/momus/config/SecurityConfig.java
+++ b/src/main/java/no/dusken/momus/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -91,7 +92,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilterBefore(metadataGeneratorFilter(), ChannelProcessingFilter.class)
             .addFilterAfter(samlFilter(), BasicAuthenticationFilter.class)
             .authorizeRequests()
-            .antMatchers("/api/dev/**").access(String.valueOf(env.acceptsProfiles("dev")))
+            .antMatchers("/api/dev/**").access(String.valueOf(env.acceptsProfiles(Profiles.of("dev"))))
             .antMatchers("/**").fullyAuthenticated()
             .and()
             .exceptionHandling()

--- a/src/main/java/no/dusken/momus/config/WebsocketConfig.java
+++ b/src/main/java/no/dusken/momus/config/WebsocketConfig.java
@@ -7,14 +7,14 @@ import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurationSupport;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @EnableAsync
-class WebsocketConfig extends AbstractWebSocketMessageBrokerConfigurer {
+class WebsocketConfig extends WebSocketMessageBrokerConfigurationSupport {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {

--- a/src/main/java/no/dusken/momus/config/WebsocketConfig.java
+++ b/src/main/java/no/dusken/momus/config/WebsocketConfig.java
@@ -9,17 +9,17 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurationSupport;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @EnableAsync
-class WebsocketConfig extends WebSocketMessageBrokerConfigurationSupport {
+class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/ws");
         config.setApplicationDestinationPrefixes("/ws");
+        config.enableSimpleBroker("/ws");
     }
 
 	@Override

--- a/src/main/java/no/dusken/momus/controller/AdvertController.java
+++ b/src/main/java/no/dusken/momus/controller/AdvertController.java
@@ -16,42 +16,45 @@
 
 package no.dusken.momus.controller;
 
-import no.dusken.momus.model.*;
-import no.dusken.momus.service.AdvertService;
-import no.dusken.momus.service.repository.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import no.dusken.momus.model.Advert;
+import no.dusken.momus.service.AdvertService;
 
 @RestController
 @RequestMapping("/api/advert")
 public class AdvertController {
+    private final AdvertService advertService;
 
-    @Autowired
-    private AdvertService advertService;
-
-    @Autowired
-    private AdvertRepository advertRepository;
-
-    @GetMapping
-    public @ResponseBody List<Advert> getAllAdverts(){
-        return advertRepository.findAll();
+    public AdvertController(AdvertService advertService) {
+        this.advertService = advertService;
     }
 
+    @GetMapping
+    public List<Advert> getAllAdverts(){
+        return advertService.getAllAdverts();
+    }
 
     @GetMapping("/{id}")
-    public @ResponseBody Advert getAdvertByID(@PathVariable Long id) {
+    public Advert getAdvertByID(@PathVariable Long id) {
         return advertService.getAdvertById(id);
     }
 
     @PostMapping
-    public @ResponseBody Advert saveAdvert(@RequestBody Advert advert){
-        return advertService.saveAdvert(advert);
+    public Advert createAdvert(@RequestBody Advert advert){
+        return advertService.createAdvert(advert);
     }
 
     @PatchMapping("{id}/comment")
-    public @ResponseBody Advert updateComment(@PathVariable Long id, @RequestBody String comment){
+    public Advert updateComment(@PathVariable Long id, @RequestBody String comment){
         return advertService.updateComment(id, comment);
     }
 

--- a/src/main/java/no/dusken/momus/controller/DevController.java
+++ b/src/main/java/no/dusken/momus/controller/DevController.java
@@ -34,7 +34,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import no.dusken.momus.config.MockToken;

--- a/src/main/java/no/dusken/momus/controller/DevController.java
+++ b/src/main/java/no/dusken/momus/controller/DevController.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -96,13 +97,13 @@ public class DevController {
     LdapSyncer ldapSyncer;
 
     @GetMapping("/ldaptest")
-    public @ResponseBody String ldaptest() {
+    public String ldaptest() {
         ldapSyncer.sync();
         return "oook";
     }
 
     @PostMapping("/generatedata")
-    public @ResponseBody String generatePublicationsAndArticles() {
+    public String generatePublicationsAndArticles() {
         Random random = new Random();
 
         List<ArticleStatus> articleStatuses = articleStatusRepository.findAll();
@@ -114,12 +115,12 @@ public class DevController {
         Publication p1 = new Publication();
         p1.setName("UD #1");
         p1.setReleaseDate(LocalDate.now().plusDays(7));
-        p1 = publicationService.savePublication(p1, 50);
+        p1 = publicationService.createPublication(p1, 50);
 
         Publication p2 = new Publication();
         p2.setName("UD #2");
         p2.setReleaseDate(LocalDate.now().plusDays(14));
-        p2 = publicationService.savePublication(p2, 50);
+        p2 = publicationService.createPublication(p2, 50);
 
         Article a1 = new Article();
         a1.setName("Lorem Ipsum");
@@ -189,13 +190,13 @@ public class DevController {
     }
 
     @GetMapping("/devmode")
-    public @ResponseBody boolean isDevmode() {
-        return env.acceptsProfiles("dev");
+    public boolean isDevmode() {
+        return env.acceptsProfiles(Profiles.of("dev"));
     }
 
     @GetMapping("/noauth")
-    public @ResponseBody boolean isNoAuth() {
-        return env.acceptsProfiles("noAuth");
+    public boolean isNoAuth() {
+        return env.acceptsProfiles(Profiles.of("noAuth"));
     }
 
     @PostMapping("/login")

--- a/src/main/java/no/dusken/momus/controller/EnvironmentController.java
+++ b/src/main/java/no/dusken/momus/controller/EnvironmentController.java
@@ -2,6 +2,7 @@ package no.dusken.momus.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -18,11 +19,11 @@ public class EnvironmentController {
     private Environment env;
 
     @GetMapping("/all")
-    public @ResponseBody Map<String, Object> allEnv() {
+    public Map<String, Object> allEnv() {
         Map<String, Object> values = new HashMap<>();
         values.put("version", env.getProperty("momus.version"));
-        values.put("devmode", env.acceptsProfiles("dev"));
-        values.put("noAuth", env.acceptsProfiles("noAuth"));
+        values.put("devmode", env.acceptsProfiles(Profiles.of("dev")));
+        values.put("noAuth", env.acceptsProfiles(Profiles.of("noAuth")));
         return values;
     }
 }

--- a/src/main/java/no/dusken/momus/controller/EnvironmentController.java
+++ b/src/main/java/no/dusken/momus/controller/EnvironmentController.java
@@ -1,15 +1,14 @@
 package no.dusken.momus.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/env")

--- a/src/main/java/no/dusken/momus/controller/NewsItemController.java
+++ b/src/main/java/no/dusken/momus/controller/NewsItemController.java
@@ -17,56 +17,42 @@
 package no.dusken.momus.controller;
 
 import no.dusken.momus.authorization.AdminAuthorization;
-import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.*;
 import no.dusken.momus.service.NewsItemService;
-import no.dusken.momus.service.repository.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletResponse;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 
 @RestController
 @RequestMapping("/api/newsitem")
 public class NewsItemController {
+    private final NewsItemService newsItemService;
 
-    @Autowired
-    NewsItemRepository newsItemRepository;
-
-    @Autowired
-    NewsItemService newsItemService;
+    public NewsItemController(NewsItemService newsItemService) {
+        this.newsItemService = newsItemService;
+    }
 
     @GetMapping
-    public @ResponseBody List<NewsItem> getAllNewsItems() {
-        return newsItemRepository.findAll();
+    public List<NewsItem> getAllNewsItems() {
+        return newsItemService.getAllNewsItems();
+    }
+
+    @GetMapping("/{newsItemId}")
+    public NewsItem getNewsItem(@PathVariable Long newsItemId){
+        return newsItemService.getNewsItemById(newsItemId);
     }
 
     @PostMapping
     @AdminAuthorization
-    public @ResponseBody NewsItem saveNewsItem(@RequestBody NewsItem newsItem) {
-        newsItem.setDate(ZonedDateTime.now());
-        return newsItemRepository.save(newsItem);
-    }
-
-    @GetMapping("/{newsItemId}")
-    public @ResponseBody NewsItem getNewsItem(@PathVariable Long newsItemId){
-        NewsItem newsItem = newsItemRepository.findOne(newsItemId);
-        if(newsItem == null){
-            throw new RestException("NewsItem with given id not found", HttpServletResponse.SC_NOT_FOUND);
-        }
-        return newsItem;
+    public NewsItem createNewsItem(@RequestBody NewsItem newsItem) {
+        return newsItemService.createNewsItem(newsItem);
     }
 
     @PutMapping("/{newsItemId}")
     @AdminAuthorization
     public @ResponseBody NewsItem updateNewsItem(@RequestBody NewsItem newsItem, @PathVariable Long newsItemId) {
-        if(!newsItemRepository.exists(newsItemId)){
-            throw new RestException("NewsItem with given id not found", HttpServletResponse.SC_NOT_FOUND);
-        }
-        return newsItemService.updateNewsItem(newsItem);
+        return newsItemService.updateNewsItem(newsItemId, newsItem);
     }
 
 

--- a/src/main/java/no/dusken/momus/controller/NewsItemController.java
+++ b/src/main/java/no/dusken/momus/controller/NewsItemController.java
@@ -51,7 +51,7 @@ public class NewsItemController {
 
     @PutMapping("/{newsItemId}")
     @AdminAuthorization
-    public @ResponseBody NewsItem updateNewsItem(@RequestBody NewsItem newsItem, @PathVariable Long newsItemId) {
+    public NewsItem updateNewsItem(@RequestBody NewsItem newsItem, @PathVariable Long newsItemId) {
         return newsItemService.updateNewsItem(newsItemId, newsItem);
     }
 

--- a/src/main/java/no/dusken/momus/controller/PageController.java
+++ b/src/main/java/no/dusken/momus/controller/PageController.java
@@ -30,28 +30,28 @@ public class PageController {
     }
 
     @GetMapping("/{id}")
-    public @ResponseBody Page getById(@PathVariable Long id) {
-        return pageRepository.findOne(id);
+    public Page getById(@PathVariable Long id) {
+        return pageService.getPageById(id);
     }
 
     @GetMapping
     @JsonView(SerializationViews.Simple.class)
-    public @ResponseBody List<Page> getByPublicationId(@RequestParam Long publicationId) {
-        return pageRepository.findByPublicationId(publicationId);
+    public List<Page> getByPublicationId(@RequestParam Long publicationId) {
+        return pageService.getPagesInPublication(publicationId);
     }
 
     @GetMapping("/page-order")
-    public @ResponseBody PageOrder getPageOrderByPublicationId(@RequestParam Long publicationId) {
-        return new PageOrder(publicationId, pageRepository.getPageOrderByPublicationId(publicationId));
+    public PageOrder getPageOrderByPublicationId(@RequestParam Long publicationId) {
+        return pageService.getPageOrderInPublication(publicationId);
     }
 
     @PutMapping("/page-order")
-    public @ResponseBody void setPageOrder(@RequestBody PageOrder pageOrder) {
+    public void setPageOrder(@RequestBody PageOrder pageOrder) {
         pageService.setPageOrder(pageOrder);
     }
 
     @PostMapping("/empty")
-    public @ResponseBody List<Page> createEmptyPagesInPublication(
+    public List<Page> createEmptyPagesInPublication(
             @RequestParam Long publicationId,
             @RequestParam Integer afterPage,
             @RequestParam(required = false, defaultValue = "1") Integer numPages
@@ -65,7 +65,7 @@ public class PageController {
     }
 
     @PatchMapping("/{id}/metadata")
-    public @ResponseBody Page updateMetadata(@PathVariable Long id, @RequestBody Page page) {
+    public Page updateMetadata(@PathVariable Long id, @RequestBody Page page) {
         return pageService.updateMetadata(id, page);
     }
 
@@ -75,8 +75,7 @@ public class PageController {
     }
 
     @GetMapping("/layoutstatuscounts")
-    public @ResponseBody
-    Map<Long,Integer> getStatusCountsByPubId(@RequestParam Long pubid){
+    public Map<Long,Integer> getStatusCountsByPubId(@RequestParam Long pubid){
         List<LayoutStatus> statuses = layoutStatusRepository.findAll();
         Map<Long, Integer> map = new HashMap<>();
         for (LayoutStatus status : statuses) {
@@ -86,7 +85,7 @@ public class PageController {
     }
 
     @GetMapping("/layoutstatuscounts/{status}")
-    public @ResponseBody int getStatusCount(@PathVariable String status, @PathVariable Long id){
+    public int getStatusCount(@PathVariable String status, @PathVariable Long id){
         Long statusId = layoutStatusRepository.findByName(status).getId();
         return pageRepository.countByLayoutStatusIdAndPublicationId(statusId, id);
     }

--- a/src/main/java/no/dusken/momus/controller/PersonController.java
+++ b/src/main/java/no/dusken/momus/controller/PersonController.java
@@ -44,19 +44,16 @@ import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.Avatar;
 import no.dusken.momus.model.Person;
 import no.dusken.momus.service.PersonService;
-import no.dusken.momus.service.repository.AvatarRepository;
 
 @RestController
 @Transactional
 @RequestMapping("/api/person")
 public class PersonController {
     private final PersonService personService;
-    private final AvatarRepository avatarRepository;
     private final UserDetailsService userDetailsService;
 
-    public PersonController(PersonService personService, AvatarRepository avatarRepository, UserDetailsService userDetailsService) {
+    public PersonController(PersonService personService, UserDetailsService userDetailsService) {
         this.personService = personService;
-        this.avatarRepository = avatarRepository;
         this.userDetailsService = userDetailsService;
     }
 

--- a/src/main/java/no/dusken/momus/controller/PersonController.java
+++ b/src/main/java/no/dusken/momus/controller/PersonController.java
@@ -16,7 +16,28 @@
 
 package no.dusken.momus.controller;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+
 import com.google.api.client.util.IOUtils;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
 import no.dusken.momus.authentication.UserDetailsService;
 import no.dusken.momus.authorization.AdminAuthorization;
 import no.dusken.momus.exceptions.RestException;
@@ -24,21 +45,6 @@ import no.dusken.momus.model.Avatar;
 import no.dusken.momus.model.Person;
 import no.dusken.momus.service.PersonService;
 import no.dusken.momus.service.repository.AvatarRepository;
-import no.dusken.momus.service.repository.PersonRepository;
-import no.dusken.momus.service.repository.SectionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.socket.messaging.SessionConnectedEvent;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
-
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.*;
 
 @RestController
 @Transactional
@@ -55,8 +61,8 @@ public class PersonController {
     }
 
     /**
-     * Gets all active persons. In addition, if article ids are supplied, will return all contributors on those
-     * even if they are inactive
+     * Gets all active persons. In addition, if article ids are supplied, will
+     * return all contributors on those even if they are inactive
      */
     @GetMapping
     public Set<Person> getActivePersons(@RequestParam(
@@ -71,11 +77,7 @@ public class PersonController {
 
     @GetMapping("/{id}/photo")
     public void getPersonPhoto(@PathVariable("id") Long id, HttpServletResponse response) throws IOException, SQLException {
-        Avatar avatar = avatarRepository.findOne(id);
-
-        if(avatar == null) {
-            throw new RestException("No photo found for user", 404);
-        }
+        Avatar avatar = personService.getPersonPhoto(id);
 
         response.addHeader("Content-Type", "image/jpeg");
 

--- a/src/main/java/no/dusken/momus/diff/DiffUtil.java
+++ b/src/main/java/no/dusken/momus/diff/DiffUtil.java
@@ -22,7 +22,6 @@ import no.dusken.momus.model.ArticleRevision;
 import no.dusken.momus.service.repository.ArticleRevisionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -37,7 +36,7 @@ public class DiffUtil {
     @Autowired
     TagToUnicodeConverter tagToUnicodeConverter;
 
-    public @ResponseBody LinkedList<DiffMatchPatch.Diff> getDiffList(long art, long oldId, long newId) {
+    public LinkedList<DiffMatchPatch.Diff> getDiffList(long art, long oldId, long newId) {
         List<ArticleRevision> revision = articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(art);
 
         if (oldId > newId) {

--- a/src/main/java/no/dusken/momus/ldap/PersonMapper.java
+++ b/src/main/java/no/dusken/momus/ldap/PersonMapper.java
@@ -105,7 +105,7 @@ public class PersonMapper implements AttributesMapper<Person> {
      * reference integrity of old articles.
      */
     private Long findFreeId(){
-        while(personRepository.exists(lastId)){ // New person
+        while(personRepository.existsById(lastId)){ // New person
             lastId++;
         }
         return lastId;

--- a/src/main/java/no/dusken/momus/service/AdvertService.java
+++ b/src/main/java/no/dusken/momus/service/AdvertService.java
@@ -23,15 +23,15 @@ import no.dusken.momus.model.websocket.Action;
 import no.dusken.momus.service.repository.AdvertRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 import javax.servlet.http.HttpServletResponse;
 
 @Service
 @Slf4j
 public class AdvertService {
-
     private final AdvertRepository advertRepository;
     private final MessagingService messagingService;
-
 
     public AdvertService(AdvertRepository advertRepository, MessagingService messagingService) {
         this.advertRepository = advertRepository;
@@ -39,13 +39,15 @@ public class AdvertService {
     }
 
     public Advert getAdvertById(Long id) {
-        if(!advertRepository.exists(id)) {
-            throw new RestException("Advert with id=" + id + " not found", HttpServletResponse.SC_NOT_FOUND);
-        }
-        return advertRepository.findOne(id);
+        return advertRepository.findById(id)
+            .orElseThrow(() -> new RestException("Advert with id=" + id + " not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
-    public Advert saveAdvert(Advert advert){
+    public List<Advert> getAllAdverts() {
+        return advertRepository.findAll();
+    }
+
+    public Advert createAdvert(Advert advert){
         Advert newAdvert = advertRepository.saveAndFlush(advert);
         log.info("Advert with id {} creatd with data: {}", newAdvert.getId(), newAdvert);
 
@@ -65,5 +67,4 @@ public class AdvertService {
         advert.setComment(comment);
         return updateAdvert(advert);
     }
-
 }

--- a/src/main/java/no/dusken/momus/service/ArticleService.java
+++ b/src/main/java/no/dusken/momus/service/ArticleService.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.extern.slf4j.Slf4j;
 import no.dusken.momus.exceptions.RestException;
@@ -284,6 +285,7 @@ public class ArticleService {
      * Will get latest changes from google drive and update article content
      */
     @Scheduled(cron = "0 * * * * *")
+    @Transactional
     public void sync() {
         Set<String> modified = googleDriveService.findModifiedFileIds();
         articleRepository.findByGoogleDriveIdIn(modified).forEach(article -> {

--- a/src/main/java/no/dusken/momus/service/ArticleService.java
+++ b/src/main/java/no/dusken/momus/service/ArticleService.java
@@ -16,59 +16,53 @@
 
 package no.dusken.momus.service;
 
-import com.google.api.services.drive.model.File;
-import lombok.extern.slf4j.Slf4j;
-import no.dusken.momus.exceptions.RestException;
-import no.dusken.momus.model.*;
-import no.dusken.momus.model.websocket.Action;
-import no.dusken.momus.service.drive.GoogleDriveService;
-import no.dusken.momus.service.indesign.IndesignExport;
-import no.dusken.momus.service.indesign.IndesignGenerator;
-import no.dusken.momus.service.repository.*;
-import no.dusken.momus.service.search.ArticleQuery;
-import no.dusken.momus.service.search.ArticleQueryBuilder;
-import no.dusken.momus.service.search.ArticleSearchParams;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.servlet.http.HttpServletResponse;
-import java.time.Duration;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
+import com.google.api.services.drive.model.File;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+import no.dusken.momus.exceptions.RestException;
+import no.dusken.momus.model.Article;
+import no.dusken.momus.model.ArticleRevision;
+import no.dusken.momus.model.ArticleStatus;
+import no.dusken.momus.model.Person;
+import no.dusken.momus.model.websocket.Action;
+import no.dusken.momus.service.drive.GoogleDriveService;
+import no.dusken.momus.service.indesign.IndesignExport;
+import no.dusken.momus.service.indesign.IndesignGenerator;
+import no.dusken.momus.service.repository.ArticleRepository;
+import no.dusken.momus.service.repository.ArticleReviewRepository;
+import no.dusken.momus.service.repository.ArticleRevisionRepository;
+import no.dusken.momus.service.repository.ArticleStatusRepository;
+import no.dusken.momus.service.repository.PersonRepository;
+import no.dusken.momus.service.search.ArticleQuery;
+import no.dusken.momus.service.search.ArticleQueryBuilder;
+import no.dusken.momus.service.search.ArticleSearchParams;
 
 @Service
 @Slf4j
 public class ArticleService {
-    @Autowired
-    private ArticleRepository articleRepository;
-
-    @Autowired
-    private ArticleRevisionRepository articleRevisionRepository;
-
-    @Autowired
-    private ArticleStatusRepository articleStatusRepository;
-
-    @Autowired
-    private ArticleReviewRepository articleReviewRepository;
-
-    @Autowired
-    private IndesignGenerator indesignGenerator;
-
-    @Autowired
-    private GoogleDriveService googleDriveService;
-
-    @Autowired
-    private ArticleQueryBuilder articleQueryBuilder;
-
-    @Autowired
-    private MessagingService messagingService;
+    private final ArticleRepository articleRepository;
+    private final ArticleRevisionRepository articleRevisionRepository;
+    private final ArticleStatusRepository articleStatusRepository;
+    private final ArticleReviewRepository articleReviewRepository;
+    private final PersonRepository personRepository;
+    private final ArticleQueryBuilder articleQueryBuilder;
+    private final GoogleDriveService googleDriveService;
+    private final MessagingService messagingService;
+    private final IndesignGenerator indesignGenerator;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -76,21 +70,43 @@ public class ArticleService {
     @Value("${drive.syncEnabled}")
     private boolean driveEnabled;
 
+    public ArticleService(ArticleRepository articleRepository, ArticleRevisionRepository articleRevisionRepository,
+        ArticleStatusRepository articleStatusRepository,
+        ArticleReviewRepository articleReviewRepository,
+        PersonRepository personRepository,
+        ArticleQueryBuilder articleQueryBuilder,
+        GoogleDriveService googleDriveService,
+        MessagingService messagingService,
+        IndesignGenerator indesignGenerator
+    ) {
+        this.articleRepository = articleRepository;
+        this.articleRevisionRepository = articleRevisionRepository;
+        this.articleStatusRepository = articleStatusRepository;
+        this.articleReviewRepository = articleReviewRepository;
+        this.personRepository = personRepository;
+        this.articleQueryBuilder = articleQueryBuilder;
+        this.googleDriveService = googleDriveService;
+        this.messagingService = messagingService;
+        this.indesignGenerator = indesignGenerator;
+    }
+
     public Article getArticleById(Long id) {
-        if(!articleRepository.exists(id)) {
-            throw new RestException("Article with id=" + id + " not found", HttpServletResponse.SC_NOT_FOUND);
-        }
-        return articleRepository.findOne(id);
+        return articleRepository.findById(id)
+            .orElseThrow(() -> new RestException("Article with id="+id+" not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
     public List<Article> getArticlesByIds(List<Long> ids) {
-        if(ids == null) {
-            return new ArrayList<>();
-        }
-        return ids.stream().map(this::getArticleById).collect(Collectors.toList());
+        return articleRepository.findAllById(ids);
     }
 
-    public Article saveArticle(Article article) {
+    public List<Article> getLastArticlesForUser(Long userId) {
+        Person user = personRepository.findById(userId)
+            .orElseThrow(() -> new RestException("User not found", HttpServletResponse.SC_NOT_FOUND));
+        
+        return articleRepository.findByJournalistsOrPhotographersOrGraphicsContains(user, new PageRequest(0, 10));
+    }
+
+    public Article createArticle(Article article) {
         if(driveEnabled) {
             File document = googleDriveService.createDocument(article.getName());
 
@@ -101,8 +117,8 @@ public class ArticleService {
             article.setGoogleDriveId(document.getId());
         }
 
-        if(article.getStatus() == null) { article.setStatus(articleStatusRepository.findOne(2L)); }
-        if(article.getReview() == null) { article.setReview(articleReviewRepository.findOne(1L)); }
+        article.setStatus(articleStatusRepository.findById(2L).get());
+        article.setReview(articleReviewRepository.findById(1L).get());
 
         Article newArticle = articleRepository.saveAndFlush(article);
         log.info("Article with id {} created with data: {}", newArticle.getId(), newArticle);
@@ -120,7 +136,7 @@ public class ArticleService {
     }
 
     public Article updateArticleContent(Article article) {
-        Article existing = articleRepository.findOne(article.getId());
+        Article existing = getArticleById(article.getId());
         String newContent = article.getContent();
         String oldContent = existing.getContent();
 
@@ -264,13 +280,7 @@ public class ArticleService {
     }
 
     private ArticleRevision getLastRevision(Article article) {
-        List<ArticleRevision> revisions = articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(article.getId());
-        
-        if (revisions.size() == 0) {
-            return null;
-        }
-
-        return articleRevisionRepository.findOne(revisions.get(0).getId());
+        return articleRevisionRepository.findFirstByArticleIdOrderBySavedDateDesc(article.getId()).orElse(null);
     }
 
     public static String createRawContent(Article article){

--- a/src/main/java/no/dusken/momus/service/ArticleService.java
+++ b/src/main/java/no/dusken/momus/service/ArticleService.java
@@ -124,8 +124,8 @@ public class ArticleService {
             article.setGoogleDriveId(document.getId());
         }
 
-        article.setStatus(articleStatusRepository.findById(2L).get());
-        article.setReview(articleReviewRepository.findById(1L).get());
+        article.setStatus(articleStatusRepository.findById(2L).orElse(null));
+        article.setReview(articleReviewRepository.findById(1L).orElse(null));
 
         Article newArticle = articleRepository.saveAndFlush(article);
         log.info("Article with id {} created with data: {}", newArticle.getId(), newArticle);

--- a/src/main/java/no/dusken/momus/service/ArticleService.java
+++ b/src/main/java/no/dusken/momus/service/ArticleService.java
@@ -99,6 +99,10 @@ public class ArticleService {
         return articleRepository.findAllById(ids);
     }
 
+    public List<Article> getArticlesInPublication(Long publicationId) {
+        return articleRepository.findByPublicationId(publicationId);
+    }
+
     public List<Article> getLastArticlesForUser(Long userId) {
         Person user = personRepository.findById(userId)
             .orElseThrow(() -> new RestException("User not found", HttpServletResponse.SC_NOT_FOUND));

--- a/src/main/java/no/dusken/momus/service/KeyValueService.java
+++ b/src/main/java/no/dusken/momus/service/KeyValueService.java
@@ -33,7 +33,7 @@ public class KeyValueService {
      * Returns the value belonging to the key, or null if key not found
      */
     public String getValue(String key) {
-        KeyValue keyValue = keyValueRepository.getOne(key);
+        KeyValue keyValue = keyValueRepository.findById(key).orElse(null);
         return keyValue != null ? keyValue.getValue() : null;
     }
 

--- a/src/main/java/no/dusken/momus/service/KeyValueService.java
+++ b/src/main/java/no/dusken/momus/service/KeyValueService.java
@@ -33,7 +33,7 @@ public class KeyValueService {
      * Returns the value belonging to the key, or null if key not found
      */
     public String getValue(String key) {
-        KeyValue keyValue = keyValueRepository.findOne(key);
+        KeyValue keyValue = keyValueRepository.getOne(key);
         return keyValue != null ? keyValue.getValue() : null;
     }
 

--- a/src/main/java/no/dusken/momus/service/NewsItemService.java
+++ b/src/main/java/no/dusken/momus/service/NewsItemService.java
@@ -16,25 +16,47 @@
 
 package no.dusken.momus.service;
 
+import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.*;
 import no.dusken.momus.service.repository.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+@Slf4j
 @Service
 public class NewsItemService {
+    private final NewsItemRepository newsItemRepository;
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    public NewsItemService(NewsItemRepository newsItemRepository) {
+        this.newsItemRepository = newsItemRepository;
+    }
 
-    @Autowired
-    private NewsItemRepository newsItemRepository;
+    public List<NewsItem> getAllNewsItems() {
+        return newsItemRepository.findAll();
+    }
 
-    public NewsItem updateNewsItem(NewsItem newsItem){
-        newsItem = newsItemRepository.save(newsItem);
+    public NewsItem getNewsItemById(Long id) {
+        return newsItemRepository.findById(id)
+            .orElseThrow(() -> new RestException("Not found", 404));
+    }
 
-        logger.info("Updated newsItem {}.", newsItem.getTitle());
+    public NewsItem createNewsItem(NewsItem item) {
+        item.setDate(ZonedDateTime.now());
+        return newsItemRepository.saveAndFlush(item);
+    }
+    public NewsItem updateNewsItem(Long id, NewsItem newsItem){
+        NewsItem existing = getNewsItemById(id);
+        existing.setContent(newsItem.getContent());
+        existing.setTitle(newsItem.getTitle());
 
-        return newsItem;
+        existing = newsItemRepository.save(existing);
+
+        log.info("Updated newsItem {}.", existing.getTitle());
+
+        return existing;
     }
 }

--- a/src/main/java/no/dusken/momus/service/NewsItemService.java
+++ b/src/main/java/no/dusken/momus/service/NewsItemService.java
@@ -26,6 +26,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServletResponse;
+
 @Slf4j
 @Service
 public class NewsItemService {
@@ -41,7 +44,7 @@ public class NewsItemService {
 
     public NewsItem getNewsItemById(Long id) {
         return newsItemRepository.findById(id)
-            .orElseThrow(() -> new RestException("Not found", 404));
+            .orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
     public NewsItem createNewsItem(NewsItem item) {

--- a/src/main/java/no/dusken/momus/service/PageService.java
+++ b/src/main/java/no/dusken/momus/service/PageService.java
@@ -11,6 +11,7 @@ import no.dusken.momus.model.websocket.Action;
 import no.dusken.momus.service.repository.*;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -42,7 +43,7 @@ public class PageService {
     }
 
     public Page getPageById(Long id) {
-        return pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+        return pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
     public List<Page> getPagesInPublication(Long publicationId) {
@@ -111,7 +112,7 @@ public class PageService {
     }
 
     public void delete(Long id) {
-        Page page = pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+        Page page = pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND));
         Long publicationId = page.getPublication().getId();
 
         List<PageId> order = pageRepository.getPageOrderByPublicationId(publicationId);

--- a/src/main/java/no/dusken/momus/service/PageService.java
+++ b/src/main/java/no/dusken/momus/service/PageService.java
@@ -1,6 +1,7 @@
 package no.dusken.momus.service;
 
 import no.dusken.momus.dto.PageOrder;
+import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.LayoutStatus;
 import no.dusken.momus.model.Page;
 import no.dusken.momus.dto.PageContent;
@@ -40,6 +41,18 @@ public class PageService {
         this.messagingService = messagingService;
     }
 
+    public Page getPageById(Long id) {
+        return pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+    }
+
+    public List<Page> getPagesInPublication(Long publicationId) {
+        return pageRepository.findByPublicationId(publicationId);
+    }
+
+    public PageOrder getPageOrderInPublication(Long publicationId) {
+        return new PageOrder(publicationId, pageRepository.getPageOrderByPublicationId(publicationId));
+    }
+
     public List<Page> createEmptyPagesInPublication(Long publicationId, Integer afterPage, Integer numPages) {
         List<PageId> pageOrder = pageRepository.getPageOrderByPublicationId(publicationId);
         List<Page> createdPages = new ArrayList<>();
@@ -65,7 +78,7 @@ public class PageService {
     }
 
     public Page updateMetadata(Long id, Page page) {
-        Page existing = pageRepository.findOne(id);
+        Page existing = pageRepository.getOne(id);
 
         existing.setNote(page.getNote());
         existing.setLayoutStatus(page.getLayoutStatus());
@@ -89,16 +102,16 @@ public class PageService {
     }
 
     public void setContent(Long id, PageContent content) {
-        Page existing = pageRepository.findOne(id);
-        existing.setArticles(new HashSet<>(articleRepository.findAll(content.getArticles())));
-        existing.setAdverts(new HashSet<>(advertRepository.findAll(content.getAdverts())));
+        Page existing = pageRepository.getOne(id);
+        existing.setArticles(new HashSet<>(articleRepository.findAllById(content.getArticles())));
+        existing.setAdverts(new HashSet<>(advertRepository.findAllById(content.getAdverts())));
         pageRepository.saveAndFlush(existing);
 
         messagingService.broadcastEntityAction(content, Action.UPDATE);
     }
 
     public void delete(Long id) {
-        Page page = pageRepository.findOne(id);
+        Page page = pageRepository.findById(id).or;
         Long publicationId = page.getPublication().getId();
 
         List<PageId> order = pageRepository.getPageOrderByPublicationId(publicationId);

--- a/src/main/java/no/dusken/momus/service/PageService.java
+++ b/src/main/java/no/dusken/momus/service/PageService.java
@@ -111,7 +111,7 @@ public class PageService {
     }
 
     public void delete(Long id) {
-        Page page = pageRepository.findById(id).or;
+        Page page = pageRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
         Long publicationId = page.getPublication().getId();
 
         List<PageId> order = pageRepository.getPageOrderByPublicationId(publicationId);
@@ -119,6 +119,6 @@ public class PageService {
         setPageOrder(order, publicationId);
 
         messagingService.broadcastEntityAction(page, Action.DELETE);
-        pageRepository.delete(id);
+        pageRepository.deleteById(id);
     }
 }

--- a/src/main/java/no/dusken/momus/service/PageService.java
+++ b/src/main/java/no/dusken/momus/service/PageService.java
@@ -78,7 +78,7 @@ public class PageService {
     }
 
     public Page updateMetadata(Long id, Page page) {
-        Page existing = pageRepository.getOne(id);
+        Page existing = getPageById(id);
 
         existing.setNote(page.getNote());
         existing.setLayoutStatus(page.getLayoutStatus());
@@ -102,7 +102,7 @@ public class PageService {
     }
 
     public void setContent(Long id, PageContent content) {
-        Page existing = pageRepository.getOne(id);
+        Page existing = getPageById(id);
         existing.setArticles(new HashSet<>(articleRepository.findAllById(content.getArticles())));
         existing.setAdverts(new HashSet<>(advertRepository.findAllById(content.getAdverts())));
         pageRepository.saveAndFlush(existing);

--- a/src/main/java/no/dusken/momus/service/PersonService.java
+++ b/src/main/java/no/dusken/momus/service/PersonService.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import no.dusken.momus.exceptions.RestException;
+import no.dusken.momus.model.Avatar;
 import no.dusken.momus.model.Person;
 import no.dusken.momus.model.Section;
+import no.dusken.momus.service.repository.AvatarRepository;
 import no.dusken.momus.service.repository.PersonRepository;
 import no.dusken.momus.service.repository.SectionRepository;
 
@@ -19,6 +21,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.servlet.http.HttpServletResponse;
+
 @Service
 @Slf4j
 public class PersonService {
@@ -26,6 +30,7 @@ public class PersonService {
     private final PersonRepository personRepository;
     private final ArticleService articleService;
     private final SectionRepository sectionRepository;
+    private final AvatarRepository avatarRepository;
     private final SimpUserRegistry userRegistry;
 
     private final Map<String, SessionState> sessionStates;
@@ -34,10 +39,12 @@ public class PersonService {
             PersonRepository personRepository,
             ArticleService articleRepository,
             SectionRepository sectionRepository,
+            AvatarRepository avatarRepository,
             SimpUserRegistry userRegistry
     ) {
         this.personRepository = personRepository;
         this.articleService = articleRepository;
+        this.avatarRepository = avatarRepository;
         this.sectionRepository = sectionRepository;
         this.userRegistry = userRegistry;
 
@@ -66,6 +73,11 @@ public class PersonService {
         });
 
         return persons;
+    }
+
+    public Avatar getPersonPhoto(Long id) {
+        return avatarRepository.findById(id)
+            .orElseThrow(() -> new RestException("No photo found for user", HttpServletResponse.SC_NOT_FOUND));
     }
 
     public Set<Person> getAllLoggedInPersons() {

--- a/src/main/java/no/dusken/momus/service/PersonService.java
+++ b/src/main/java/no/dusken/momus/service/PersonService.java
@@ -52,12 +52,12 @@ public class PersonService {
     }
 
     public Person getPersonById(Long id) {
-        return personRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+        return personRepository.findById(id).orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
     public Person updateFavouritesection(Person person, Long sectionId) {
         Section section = sectionRepository.findById(sectionId)
-            .orElseThrow(() -> new RestException("Section not found", 404));
+            .orElseThrow(() -> new RestException("Section not found", HttpServletResponse.SC_NOT_FOUND));
 
         person.setFavouritesection(section);
 

--- a/src/main/java/no/dusken/momus/service/PublicationService.java
+++ b/src/main/java/no/dusken/momus/service/PublicationService.java
@@ -21,9 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.dusken.momus.dto.SimplePublication;
 import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.*;
-import no.dusken.momus.service.repository.ArticleRepository;
 import no.dusken.momus.service.repository.PublicationRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;

--- a/src/main/java/no/dusken/momus/service/PublicationService.java
+++ b/src/main/java/no/dusken/momus/service/PublicationService.java
@@ -52,7 +52,7 @@ public class PublicationService {
     }
 
     public Publication getPublicationById(Long id) {
-        return publicationRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+        return publicationRepository.findById(id).orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/no/dusken/momus/service/PublicationService.java
+++ b/src/main/java/no/dusken/momus/service/PublicationService.java
@@ -19,6 +19,7 @@ package no.dusken.momus.service;
 
 import lombok.extern.slf4j.Slf4j;
 import no.dusken.momus.dto.SimplePublication;
+import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.model.*;
 import no.dusken.momus.service.repository.ArticleRepository;
 import no.dusken.momus.service.repository.PublicationRepository;
@@ -29,17 +30,32 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
+import javax.servlet.http.HttpServletResponse;
+
 @Service
 @Slf4j
 public class PublicationService {
-    @Autowired
-    private PublicationRepository publicationRepository;
+    private final PublicationRepository publicationRepository;
+    private final PageService pageService;
+    private final ArticleService articleService;
 
-    @Autowired
-    private PageService pageService;
+    public PublicationService(
+        PublicationRepository publicationRepository,
+        PageService pageService,
+        ArticleService articleService
+    ) {
+        this.publicationRepository = publicationRepository;
+        this.pageService = pageService;
+        this.articleService = articleService;
+    }
 
-    @Autowired
-    private ArticleRepository articleRepository;
+    public List<SimplePublication> getAllPublications() {
+        return publicationRepository.findAllByOrderByReleaseDateDesc();
+    }
+
+    public Publication getPublicationById(Long id) {
+        return publicationRepository.findById(id).orElseThrow(() -> new RestException("Not found", 404));
+    }
 
     /**
      *
@@ -53,7 +69,11 @@ public class PublicationService {
         return publicationRepository.findFirstByReleaseDateAfterOrderByReleaseDate(date.minus(1, ChronoUnit.DAYS), SimplePublication.class);
     }
 
-    public Publication savePublication(Publication publication, Integer numEmptyPages){
+    public Publication createPublication(Publication publication, Integer numEmptyPages){
+        if(numEmptyPages > 100){
+            throw new RestException("You don't want to create that many empty pages", HttpServletResponse.SC_BAD_REQUEST);
+        }
+
         Publication newPublication = publicationRepository.saveAndFlush(publication);
 
         pageService.createEmptyPagesInPublication(newPublication.getId(), 0, numEmptyPages);
@@ -63,7 +83,12 @@ public class PublicationService {
         return newPublication;
     }
 
-    public Publication updatePublication(Publication publication){
+    public Publication updatePublicationMetadata(Long id, Publication publication){
+        Publication existing = getPublicationById(id);
+
+        existing.setName(publication.getName());
+        existing.setReleaseDate(publication.getReleaseDate());
+
         log.info("Updated publication {} with data: {}", publication.getName(), publication);
 
         return publicationRepository.saveAndFlush(publication);
@@ -75,7 +100,7 @@ public class PublicationService {
      * @return The generated colophon
      */
     public String generateColophon(Long pubId){
-        List<Article> articles = articleRepository.findByPublicationId(pubId);
+        List<Article> articles = articleService.getArticlesInPublication(pubId);
 
         Set<Person> journalists = new HashSet<>();
         Set<Person> photographers = new HashSet<>();

--- a/src/main/java/no/dusken/momus/service/drive/GoogleDriveService.java
+++ b/src/main/java/no/dusken/momus/service/drive/GoogleDriveService.java
@@ -16,6 +16,17 @@
 
 package no.dusken.momus.service.drive;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.GenericUrl;
@@ -27,21 +38,14 @@ import com.google.api.services.drive.model.Change;
 import com.google.api.services.drive.model.ChangeList;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.Permission;
-import lombok.extern.slf4j.Slf4j;
-import no.dusken.momus.model.Article;
-import no.dusken.momus.service.ArticleService;
-import no.dusken.momus.service.KeyValueService;
-import no.dusken.momus.service.repository.ArticleRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.GeneralSecurityException;
-import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+import no.dusken.momus.model.Article;
+import no.dusken.momus.service.KeyValueService;
 
 @Service
 @Slf4j

--- a/src/main/java/no/dusken/momus/service/repository/AdvertRepository.java
+++ b/src/main/java/no/dusken/momus/service/repository/AdvertRepository.java
@@ -22,6 +22,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AdvertRepository extends JpaRepository<Advert, Long> {
-
-
 }

--- a/src/main/java/no/dusken/momus/service/repository/ArticleRevisionRepository.java
+++ b/src/main/java/no/dusken/momus/service/repository/ArticleRevisionRepository.java
@@ -20,10 +20,12 @@ import no.dusken.momus.model.ArticleRevision;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArticleRevisionRepository extends JpaRepository<ArticleRevision, Long> {
-
+    Optional<ArticleRevision> findFirstByArticleIdOrderBySavedDateDesc(Long id);
     List<ArticleRevision> findByArticleIdOrderBySavedDateDesc(Long id);
 }

--- a/src/main/java/no/dusken/momus/service/search/ArticleQueryBuilder.java
+++ b/src/main/java/no/dusken/momus/service/search/ArticleQueryBuilder.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.service.repository.PersonRepository;
 
 import java.util.ArrayList;
@@ -79,7 +80,7 @@ public class ArticleQueryBuilder {
                 conditions.add("( :personid" + personCount + " member of a.journalists or " +
                         ":personid" + personCount + " member of a.photographers or " +
                         ":personid" + personCount + " member of a.graphics )");
-                queryParams.put("personid" + personCount++, personRepository.findOne(person));
+                queryParams.put("personid" + personCount++, personRepository.findById(person).orElseThrow(() -> new RestException("Not found", 404)));
             }
         }
         if (search.getSection() != null) {

--- a/src/main/java/no/dusken/momus/service/search/ArticleQueryBuilder.java
+++ b/src/main/java/no/dusken/momus/service/search/ArticleQueryBuilder.java
@@ -24,6 +24,7 @@ import org.springframework.util.StringUtils;
 import no.dusken.momus.exceptions.RestException;
 import no.dusken.momus.service.repository.PersonRepository;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -80,7 +81,7 @@ public class ArticleQueryBuilder {
                 conditions.add("( :personid" + personCount + " member of a.journalists or " +
                         ":personid" + personCount + " member of a.photographers or " +
                         ":personid" + personCount + " member of a.graphics )");
-                queryParams.put("personid" + personCount++, personRepository.findById(person).orElseThrow(() -> new RestException("Not found", 404)));
+                queryParams.put("personid" + personCount++, personRepository.findById(person).orElseThrow(() -> new RestException("Not found", HttpServletResponse.SC_NOT_FOUND)));
             }
         }
         if (search.getSection() != null) {

--- a/src/test/java/no/dusken/momus/authentication/UserDetailsServiceMock.java
+++ b/src/test/java/no/dusken/momus/authentication/UserDetailsServiceMock.java
@@ -38,6 +38,6 @@ public class UserDetailsServiceMock implements UserDetailsService {
 
     @Override
     public Person getLoggedInPerson() {
-        return personRepository.findOne(1L);
+        return personRepository.findById(1L).get();
     }
 }

--- a/src/test/java/no/dusken/momus/controller/AdvertControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/AdvertControllerTest.java
@@ -25,8 +25,8 @@ public class AdvertControllerTest extends AbstractControllerTest {
     void internalSetup() {
         super.internalSetup();
 
-        ad1 = advertService.saveAdvert(Advert.builder().name("iBok").comment("ya").build());
-        ad2 = advertService.saveAdvert(Advert.builder().name("barteguiden").comment("nope").build());
+        ad1 = advertService.createAdvert(Advert.builder().name("iBok").comment("ya").build());
+        ad2 = advertService.createAdvert(Advert.builder().name("barteguiden").comment("nope").build());
     }
 
     @Test

--- a/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
@@ -1,10 +1,12 @@
 package no.dusken.momus.controller;
 
 import no.dusken.momus.model.Article;
+import no.dusken.momus.model.ArticleReview;
 import no.dusken.momus.model.ArticleRevision;
 import no.dusken.momus.model.ArticleStatus;
 import no.dusken.momus.service.ArticleService;
 import no.dusken.momus.service.repository.ArticleRepository;
+import no.dusken.momus.service.repository.ArticleReviewRepository;
 import no.dusken.momus.service.repository.ArticleRevisionRepository;
 import no.dusken.momus.service.repository.ArticleStatusRepository;
 import no.dusken.momus.service.search.ArticleSearchParams;
@@ -13,12 +15,15 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.HashSet;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Slf4j
 public class ArticleControllerTest extends AbstractControllerTest {
 
     @Autowired
@@ -29,6 +34,9 @@ public class ArticleControllerTest extends AbstractControllerTest {
 
     @Autowired
     private ArticleStatusRepository articleStatusRepository;
+
+    @Autowired
+    private ArticleReviewRepository articleReviewRepository;
 
     @Autowired
     private ArticleRevisionRepository articleRevisionRepository;
@@ -128,11 +136,13 @@ public class ArticleControllerTest extends AbstractControllerTest {
         Article article = Article.builder()
                 .name("Artikkel")
                 .content("Innhold")
-                .status(status1)
                 .journalists(new HashSet<>())
                 .photographers(new HashSet<>())
                 .build();
         article = articleService.createArticle(article);
+        
+        article.setStatus(status1);
+        articleService.updateArticleStatus(article.getId(), article);
 
         article = articleService.updateArticleContent(article.getId(), "Nytt innhold");
 
@@ -141,7 +151,7 @@ public class ArticleControllerTest extends AbstractControllerTest {
                 .status(status2)
                 .build();
         updatedArticle.setId(article.getId());
-        articleService.updateArticleMetadata(article.getId(), updatedArticle);
+        articleService.updateArticleStatus(article.getId(), updatedArticle);
 
         List<ArticleRevision> revisions = articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(article.getId());
 

--- a/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
@@ -1,29 +1,25 @@
 package no.dusken.momus.controller;
 
-import no.dusken.momus.model.Article;
-import no.dusken.momus.model.ArticleReview;
-import no.dusken.momus.model.ArticleRevision;
-import no.dusken.momus.model.ArticleStatus;
-import no.dusken.momus.service.ArticleService;
-import no.dusken.momus.service.repository.ArticleRepository;
-import no.dusken.momus.service.repository.ArticleReviewRepository;
-import no.dusken.momus.service.repository.ArticleRevisionRepository;
-import no.dusken.momus.service.repository.ArticleStatusRepository;
-import no.dusken.momus.service.search.ArticleSearchParams;
-import no.dusken.momus.util.TestUtil;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockHttpServletResponse;
-
-import lombok.extern.slf4j.Slf4j;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.HashSet;
 import java.util.List;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
 
-@Slf4j
+import no.dusken.momus.model.Article;
+import no.dusken.momus.model.ArticleRevision;
+import no.dusken.momus.model.ArticleStatus;
+import no.dusken.momus.service.ArticleService;
+import no.dusken.momus.service.repository.ArticleRepository;
+import no.dusken.momus.service.repository.ArticleRevisionRepository;
+import no.dusken.momus.service.repository.ArticleStatusRepository;
+import no.dusken.momus.service.search.ArticleSearchParams;
+import no.dusken.momus.util.TestUtil;
+
 public class ArticleControllerTest extends AbstractControllerTest {
 
     @Autowired
@@ -34,9 +30,6 @@ public class ArticleControllerTest extends AbstractControllerTest {
 
     @Autowired
     private ArticleStatusRepository articleStatusRepository;
-
-    @Autowired
-    private ArticleReviewRepository articleReviewRepository;
 
     @Autowired
     private ArticleRevisionRepository articleRevisionRepository;

--- a/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
@@ -134,13 +134,13 @@ public class ArticleControllerTest extends AbstractControllerTest {
                 .build();
         article = articleService.createArticle(article);
 
+        article = articleService.updateArticleContent(article.getId(), "Nytt innhold");
+
         Article updatedArticle = Article.builder()
-                .content("Nytt innhold")
                 .name("Artikkel")
                 .status(status2)
                 .build();
         updatedArticle.setId(article.getId());
-        article = articleService.updateArticleContent(updatedArticle);
         articleService.updateArticleMetadata(article.getId(), updatedArticle);
 
         List<ArticleRevision> revisions = articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(article.getId());

--- a/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/ArticleControllerTest.java
@@ -39,7 +39,7 @@ public class ArticleControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testSaveArticle() throws Exception {
+    public void testCreateArticle() throws Exception {
         Article article = new Article();
         article.setName("Artikkel");
         mockMvc.perform(buildPost("/api/article", TestUtil.toJsonString(article))).andExpect(status().isOk());
@@ -132,7 +132,7 @@ public class ArticleControllerTest extends AbstractControllerTest {
                 .journalists(new HashSet<>())
                 .photographers(new HashSet<>())
                 .build();
-        article = articleService.saveArticle(article);
+        article = articleService.createArticle(article);
 
         Article updatedArticle = Article.builder()
                 .content("Nytt innhold")
@@ -159,8 +159,8 @@ public class ArticleControllerTest extends AbstractControllerTest {
         Article article2 = new Article();
         article2.setName("Art2");
 
-        article1 = articleService.saveArticle(article1);
-        article2 = articleService.saveArticle(article2);
+        article1 = articleService.createArticle(article1);
+        article2 = articleService.createArticle(article2);
 
         performGetExpectOk("/api/article/multiple?ids=" + article1.getId() + "&ids=" + article2.getId());
     }
@@ -170,7 +170,7 @@ public class ArticleControllerTest extends AbstractControllerTest {
         Article article = new Article();
         article.setName("Artikkel");
 
-        articleService.saveArticle(article);
+        articleService.createArticle(article);
         ArticleSearchParams params = new ArticleSearchParams(
                 "Artikkel",
                 null,

--- a/src/test/java/no/dusken/momus/controller/PageControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PageControllerTest.java
@@ -79,7 +79,7 @@ public class PageControllerTest extends AbstractControllerTest {
 
     @Test
     public void setContent() throws Exception {
-        Article article = articleService.saveArticle(Article.builder().name("Artikkel").build());
+        Article article = articleService.createArticle(Article.builder().name("Artikkel").build());
         Advert advert = advertService.saveAdvert(Advert.builder().name("Ad").build());
         Page page = pageRepository.findByPublicationId(publication.getId()).get(0);
 

--- a/src/test/java/no/dusken/momus/controller/PageControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PageControllerTest.java
@@ -42,7 +42,7 @@ public class PageControllerTest extends AbstractControllerTest {
 
     @Override
     void internalSetup() {
-        publication = publicationService.savePublication(Publication.builder().name("UD").releaseDate(LocalDate.now()).build(), 10);
+        publication = publicationService.createPublication(Publication.builder().name("UD").releaseDate(LocalDate.now()).build(), 10);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class PageControllerTest extends AbstractControllerTest {
     @Test
     public void setContent() throws Exception {
         Article article = articleService.createArticle(Article.builder().name("Artikkel").build());
-        Advert advert = advertService.saveAdvert(Advert.builder().name("Ad").build());
+        Advert advert = advertService.createAdvert(Advert.builder().name("Ad").build());
         Page page = pageRepository.findByPublicationId(publication.getId()).get(0);
 
         performPutExpectOk(

--- a/src/test/java/no/dusken/momus/controller/PageControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PageControllerTest.java
@@ -91,7 +91,7 @@ public class PageControllerTest extends AbstractControllerTest {
                         Collections.singletonList(article.getId()),
                         Collections.singletonList(advert.getId()))));
 
-        page = pageRepository.findOne(page.getId());
+        page = pageRepository.findById(page.getId()).get();
         assert page.getArticles().size() == 1;
         assert page.getAdverts().size() == 1;
     }
@@ -106,7 +106,7 @@ public class PageControllerTest extends AbstractControllerTest {
 
         performPatchExpectOk("/api/pages/" + page.getId() + "/metadata", TestUtil.toJsonString(page));
 
-        page = pageRepository.findOne(page.getId());
+        page = pageRepository.findById(page.getId()).get();
 
         assertEquals(true, page.isDone());
         assertEquals(s, page.getLayoutStatus());

--- a/src/test/java/no/dusken/momus/controller/PersonControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PersonControllerTest.java
@@ -53,7 +53,7 @@ public class PersonControllerTest extends AbstractControllerTest {
                 .active(true)
                 .build();
         List<Person> users = Arrays.asList(eirik, eivind);
-        personRepository.save(users);
+        personRepository.saveAll(users);
         personRepository.flush();
         performGetExpectOk("/api/person").andExpect(jsonPath("$.length()", is(users.size())));
     }

--- a/src/test/java/no/dusken/momus/controller/PersonControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PersonControllerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -60,7 +61,8 @@ public class PersonControllerTest extends AbstractControllerTest {
 
     @Test
     public void getNonexistentID() throws Exception {
-        performGetExpectOk("/api/person/2").andExpect(content().string(""));
+        mockMvc.perform(get("/api/person/2"))
+            .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/no/dusken/momus/controller/PublicationControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PublicationControllerTest.java
@@ -26,9 +26,9 @@ public class PublicationControllerTest extends AbstractControllerTest {
 
     @Override
     void internalSetup() {
-        pub1 = publicationService.savePublication(
+        pub1 = publicationService.createPublication(
                 Publication.builder().name("UD").releaseDate(LocalDate.now()).build(), 10);
-        pub2 = publicationService.savePublication(
+        pub2 = publicationService.createPublication(
                 Publication.builder().name("UD2").releaseDate(LocalDate.now().plusDays(10)).build(), 10);
     }
 
@@ -58,7 +58,7 @@ public class PublicationControllerTest extends AbstractControllerTest {
 
         performPutExpectOk("/api/publications/" + pub1.getId(), TestUtil.toJsonString(newPub1));
 
-        newPub1 = publicationRepository.findOne(pub1.getId());
+        newPub1 = publicationRepository.findById(pub1.getId()).get();
 
         assert newPub1.getName().equals("UDUD");
     }

--- a/src/test/java/no/dusken/momus/controller/PublicationControllerTest.java
+++ b/src/test/java/no/dusken/momus/controller/PublicationControllerTest.java
@@ -52,11 +52,11 @@ public class PublicationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void updatePublication() throws Exception {
+    public void updatePublicationMetadata() throws Exception {
         Publication newPub1 = Publication.builder().name("UDUD").releaseDate(pub1.getReleaseDate()).build();
         newPub1.setId(pub1.getId());
 
-        performPutExpectOk("/api/publications/" + pub1.getId(), TestUtil.toJsonString(newPub1));
+        performPatchExpectOk("/api/publications/" + pub1.getId() + "/metadata", TestUtil.toJsonString(newPub1));
 
         newPub1 = publicationRepository.findById(pub1.getId()).get();
 

--- a/src/test/java/no/dusken/momus/service/AdvertServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/AdvertServiceTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 public class AdvertServiceTest extends AbstractServiceTest {
 
     @InjectMocks
@@ -26,8 +28,7 @@ public class AdvertServiceTest extends AbstractServiceTest {
         advert = Advert.builder().name("iBok").comment("er kult").build();
         advert.setId(0L);
 
-        when(advertRepository.findOne(0L)).thenReturn(advert);
-        when(advertRepository.exists(0L)).thenReturn(true);
+        when(advertRepository.findById(0L)).thenReturn(Optional.of(advert));
         when(advertRepository.saveAndFlush(any(Advert.class)))
                 .then(invocationOnMock -> invocationOnMock.getArgument(0));
     }
@@ -43,7 +44,7 @@ public class AdvertServiceTest extends AbstractServiceTest {
     public void saveAdvert() {
         Advert a = Advert.builder().name("dusken.no").comment("oh yes").build();
 
-        advertService.saveAdvert(a);
+        advertService.createAdvert(a);
 
         verify(advertRepository, times(1)).saveAndFlush(a);
     }

--- a/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
@@ -150,9 +150,8 @@ public class ArticleServiceTest extends AbstractServiceTest {
         article1Revision1.setId(0L);
 
         when(indesignGenerator.generateFromArticle(article1)).thenReturn(new IndesignExport("meh", "meh"));
-        when(articleRepository.exists(longThat(i -> i == 1L || i == 2L ))).thenReturn(true);
-        when(articleRepository.findOne(article1.getId())).thenReturn(article1);
-        when(articleRepository.findOne(article2.getId())).thenReturn(article2);
+        when(articleRepository.findById(article1.getId())).thenReturn(Optional.of(article1));
+        when(articleRepository.findById(article2.getId())).thenReturn(Optional.of(article2));
         when(articleRepository.saveAndFlush(any(Article.class))).then(returnsFirstArg());
     }
 
@@ -271,7 +270,7 @@ public class ArticleServiceTest extends AbstractServiceTest {
         ArticleService articleServiceSpy = spy(articleService);
         doReturn(new ArticleRevision()).when(articleServiceSpy).createRevision(any(Article.class));
 
-        article = articleServiceSpy.updateArticleContent(article);
+        article = articleServiceSpy.updateArticleContent(article1.getId(), "<p>NEW CONTENT for article 1</p>");
 
         verify(articleServiceSpy, times(1)).updateArticle(article1);
         verify(articleServiceSpy, times(1)).createRevision(article1);
@@ -286,11 +285,9 @@ public class ArticleServiceTest extends AbstractServiceTest {
      */
     @Test
     public void testUpdateArticleContentNoChange() {
-        Article article = Article.builder().content(article1.getContent()).build();
-        article.setId(article1.getId());
         ArticleService articleServiceSpy = spy(articleService);
 
-        articleServiceSpy.updateArticleContent(article);
+        articleServiceSpy.updateArticleContent(article1.getId(), article1.getContent());
 
         verify(articleServiceSpy, times(0)).updateArticle(article1);
         verify(articleServiceSpy, times(0)).createRevision(article1);
@@ -313,7 +310,7 @@ public class ArticleServiceTest extends AbstractServiceTest {
     public void testCreateRevision() {
         ArticleService articleServiceSpy = spy(articleService);
 
-        when(articleRevisionRepository.findOne(any(Long.class))).thenReturn(article1Revision1);
+        when(articleRevisionRepository.findById(any(Long.class))).thenReturn(Optional.of(article1Revision1));
         when(articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(article1.getId())).thenReturn(Collections.singletonList(article1Revision1));
         when(articleRevisionRepository.save(any(ArticleRevision.class))).then(returnsFirstArg());
 

--- a/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
@@ -178,8 +178,8 @@ public class ArticleServiceTest extends AbstractServiceTest {
      * Method: {@link ArticleService#saveArticle}
      */
     @Test
-    public void testSaveArticle() {
-        article1 = articleService.saveArticle(article1);
+    public void testCreateArticle() {
+        article1 = articleService.createArticle(article1);
 
         verify(articleRepository, times(1)).saveAndFlush(article1);
     }

--- a/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/ArticleServiceTest.java
@@ -43,6 +43,12 @@ public class ArticleServiceTest extends AbstractServiceTest {
     private ArticleRevisionRepository articleRevisionRepository;
 
     @Mock
+    private ArticleStatusRepository articleStatusRepository;
+
+    @Mock
+    private ArticleReviewRepository articleReviewRepository;
+
+    @Mock
     private IndesignGenerator indesignGenerator;
 
     @InjectMocks
@@ -151,8 +157,9 @@ public class ArticleServiceTest extends AbstractServiceTest {
 
         when(indesignGenerator.generateFromArticle(article1)).thenReturn(new IndesignExport("meh", "meh"));
         when(articleRepository.findById(article1.getId())).thenReturn(Optional.of(article1));
-        when(articleRepository.findById(article2.getId())).thenReturn(Optional.of(article2));
         when(articleRepository.saveAndFlush(any(Article.class))).then(returnsFirstArg());
+        when(articleStatusRepository.findById(2L)).thenReturn(Optional.of(articleStatus1));
+        when(articleReviewRepository.findById(1L)).thenReturn(Optional.of(articleReview1));
     }
 
     /**
@@ -162,15 +169,6 @@ public class ArticleServiceTest extends AbstractServiceTest {
     public void testGetArticleById() {
         Article article = articleService.getArticleById(1L);
         assert(article.getId() == 1L);
-    }
-
-    /**
-     * Method: {@link ArticleService#getArticlesByIds}
-     */
-    @Test
-    public void testGetArticlesByIds() {
-        List<Article> articles = articleService.getArticlesByIds(new ArrayList<>(Arrays.asList(1L, 2L)));
-        assert(articles.size() == 2);
     }
 
     /**
@@ -310,8 +308,7 @@ public class ArticleServiceTest extends AbstractServiceTest {
     public void testCreateRevision() {
         ArticleService articleServiceSpy = spy(articleService);
 
-        when(articleRevisionRepository.findById(any(Long.class))).thenReturn(Optional.of(article1Revision1));
-        when(articleRevisionRepository.findByArticleIdOrderBySavedDateDesc(article1.getId())).thenReturn(Collections.singletonList(article1Revision1));
+        when(articleRevisionRepository.findFirstByArticleIdOrderBySavedDateDesc(article1.getId())).thenReturn(Optional.of(article1Revision1));
         when(articleRevisionRepository.save(any(ArticleRevision.class))).then(returnsFirstArg());
 
         // Test too old previous revision creates new

--- a/src/test/java/no/dusken/momus/service/KeyValueServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/KeyValueServiceTest.java
@@ -73,7 +73,7 @@ public class KeyValueServiceTest extends AbstractServiceTest {
 
     @Test
     public void testGetValue() {
-        when(keyValueRepository.findById(anyString())).thenReturn(null);
+        when(keyValueRepository.findById(anyString())).thenReturn(Optional.empty());
         when(keyValueRepository.findById(keyValue1.getKey())).thenReturn(Optional.of(keyValue1));
 
         String value;
@@ -97,7 +97,7 @@ public class KeyValueServiceTest extends AbstractServiceTest {
 
     @Test
     public void testGetValueAsLong() {
-        when(keyValueRepository.findById(anyString())).thenReturn(null);
+        when(keyValueRepository.findById(anyString())).thenReturn(Optional.empty());
         when(keyValueRepository.findById(keyValue1.getKey())).thenReturn(Optional.of(keyValue1));
 
         long value;

--- a/src/test/java/no/dusken/momus/service/KeyValueServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/KeyValueServiceTest.java
@@ -28,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
 import static org.mockito.AdditionalAnswers.*;
 
 @Transactional
@@ -70,8 +73,8 @@ public class KeyValueServiceTest extends AbstractServiceTest {
 
     @Test
     public void testGetValue() {
-        when(keyValueRepository.findOne(anyString())).thenReturn(null);
-        when(keyValueRepository.findOne(keyValue1.getKey())).thenReturn(keyValue1);
+        when(keyValueRepository.findById(anyString())).thenReturn(null);
+        when(keyValueRepository.findById(keyValue1.getKey())).thenReturn(Optional.of(keyValue1));
 
         String value;
 
@@ -94,8 +97,8 @@ public class KeyValueServiceTest extends AbstractServiceTest {
 
     @Test
     public void testGetValueAsLong() {
-        when(keyValueRepository.findOne(anyString())).thenReturn(null);
-        when(keyValueRepository.findOne(keyValue1.getKey())).thenReturn(keyValue1);
+        when(keyValueRepository.findById(anyString())).thenReturn(null);
+        when(keyValueRepository.findById(keyValue1.getKey())).thenReturn(Optional.of(keyValue1));
 
         long value;
 

--- a/src/test/java/no/dusken/momus/service/PageServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PageServiceTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -73,7 +74,7 @@ public class PageServiceTest extends AbstractServiceTest {
         Page existing = new Page();
         existing.setId(0L);
 
-        when(pageRepository.findOne(0L)).thenReturn(existing);
+        when(pageRepository.findById(0L)).thenReturn(Optional.of(existing));
         when(pageRepository.saveAndFlush(existing)).thenReturn(existing);
 
         Page p = Page.builder().layoutStatus(l).done(true).build();
@@ -111,9 +112,9 @@ public class PageServiceTest extends AbstractServiceTest {
                 new ArrayList<>(Collections.singletonList(0L)),
                 new ArrayList<>(Collections.singletonList(2L)));
 
-        when(pageRepository.findOne(0L)).thenReturn(p);
-        when(articleRepository.findAll(anyIterable())).thenReturn(articles);
-        when(advertRepository.findAll(anyIterable())).thenReturn(adverts);
+        when(pageRepository.findById(0L)).thenReturn(Optional.of(p));
+        when(articleRepository.findAll()).thenReturn(articles);
+        when(advertRepository.findAll()).thenReturn(adverts);
 
         pageService.setContent(0L, c);
 
@@ -131,14 +132,14 @@ public class PageServiceTest extends AbstractServiceTest {
 
         PageService pageServiceSpy = spy(pageService);
 
-        when(pageRepository.findOne(0L)).thenReturn(p);
+        when(pageRepository.findById(0L)).thenReturn(Optional.of(p));
         when(pageRepository.getPageOrderByPublicationId(publication.getId())).thenReturn(pageOrder);
 
 
         pageServiceSpy.delete(0L);
 
         verify(pageServiceSpy, times(1)).setPageOrder(pageOrder, 0L);
-        verify(pageRepository, times(1)).delete(0L);
+        verify(pageRepository, times(1)).deleteById(0L);
         verify(messagingService, times(1)).broadcastEntityAction(p, Action.DELETE);
     }
 }

--- a/src/test/java/no/dusken/momus/service/PageServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PageServiceTest.java
@@ -113,8 +113,8 @@ public class PageServiceTest extends AbstractServiceTest {
                 new ArrayList<>(Collections.singletonList(2L)));
 
         when(pageRepository.findById(0L)).thenReturn(Optional.of(p));
-        when(articleRepository.findAll()).thenReturn(articles);
-        when(advertRepository.findAll()).thenReturn(adverts);
+        when(articleRepository.findAllById(anyList())).thenReturn(articles);
+        when(advertRepository.findAllById(anyList())).thenReturn(adverts);
 
         pageService.setContent(0L, c);
 

--- a/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
@@ -41,7 +41,7 @@ public class PublicationServiceTest extends AbstractServiceTest {
     private PublicationRepository publicationRepository;
 
     @Mock
-    private ArticleRepository articleRepository;
+    private ArticleService articleService;
 
     @Mock
     private PageService pageService;
@@ -86,6 +86,7 @@ public class PublicationServiceTest extends AbstractServiceTest {
     @Test
     public void testUpdatePublicationMetadata() {
         PublicationService publicationServiceSpy = spy(publicationService);
+        when(publicationRepository.findById(publication1.getId())).thenReturn(Optional.of(publication1));
         doReturn(publication1).when(publicationRepository).saveAndFlush(publication1);
         publication1.setName("justanupdatedpubname");
         publication1 = publicationServiceSpy.updatePublicationMetadata(publication1.getId(), publication1);
@@ -112,7 +113,7 @@ public class PublicationServiceTest extends AbstractServiceTest {
                 .photographers(Collections.singleton(Person.builder().id(4L).name("Ill").build()))
                 .build();
 
-        doReturn(Arrays.asList(art, art2)).when(articleRepository).findByPublicationId(publication1.getId());
+        doReturn(Arrays.asList(art, art2)).when(articleService).getArticlesInPublication(publication1.getId());
 
         String colophon = publicationService.generateColophon(publication1.getId());
 

--- a/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
@@ -17,7 +17,6 @@
 package no.dusken.momus.service;
 
 import no.dusken.momus.model.*;
-import no.dusken.momus.service.repository.ArticleRepository;
 
 import no.dusken.momus.service.repository.PublicationRepository;
 

--- a/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
+++ b/src/test/java/no/dusken/momus/service/PublicationServiceTest.java
@@ -75,7 +75,7 @@ public class PublicationServiceTest extends AbstractServiceTest {
     public void testSavePublication() {
         doReturn(publication1).when(publicationRepository).saveAndFlush(publication1);
 
-        publicationService.savePublication(publication1, 50);
+        publicationService.createPublication(publication1, 50);
         verify(publicationRepository, times(1)).saveAndFlush(publication1);
         verify(pageService, times(1)).createEmptyPagesInPublication(publication1.getId(), 0, 50);
     }
@@ -88,7 +88,7 @@ public class PublicationServiceTest extends AbstractServiceTest {
         PublicationService publicationServiceSpy = spy(publicationService);
         doReturn(publication1).when(publicationRepository).saveAndFlush(publication1);
         publication1.setName("justanupdatedpubname");
-        publication1 = publicationServiceSpy.updatePublication(publication1);
+        publication1 = publicationServiceSpy.updatePublicationMetadata(publication1.getId(), publication1);
 
         verify(publicationRepository, times(1)).saveAndFlush(publication1);
         assertEquals("justanupdatedpubname",publication1.getName());

--- a/src/test/java/no/dusken/momus/service/search/ArticleQueryBuilderTest.java
+++ b/src/test/java/no/dusken/momus/service/search/ArticleQueryBuilderTest.java
@@ -59,8 +59,8 @@ public class ArticleQueryBuilderTest extends AbstractServiceTest {
                 .active(true)
                 .build();
 
-        when(personRepository.findOne(person1.getId())).thenReturn(person1);
-        when(personRepository.findOne(person2.getId())).thenReturn(person2);
+        when(personRepository.findById(person1.getId())).thenReturn(Optional.of(person1));
+        when(personRepository.findById(person2.getId())).thenReturn(Optional.of(person2));
     }
 
     @Before

--- a/webapp-beta/resources/publication.resource.ts
+++ b/webapp-beta/resources/publication.resource.ts
@@ -9,6 +9,7 @@ export default function publicationResourceFactory(momResource: MomResourceFacto
             id: '@id',
         },
         {
+            updateMetadata: { method: 'PATCH', params: {resource: 'metadata'} },
             active: { method: 'GET', params: {id: 'active'}, bypassInterceptor: true },
             layoutStatuses: {
                 method: 'GET', isArray: true, params: {id: 'layoutstatuses'}, cache: true, skipTransform: true,
@@ -40,6 +41,12 @@ function publicationRequestTransform(publication: Publication): PublicationSeria
 }
 
 export interface PublicationResource extends ng.resource.IResourceClass<Publication> {
+    updateMetadata(
+        params: {},
+        body: Publication,
+        success?: (publication: Publication) => void,
+        error?: (err: any) => void,
+    ): Publication;
     active(
         params?: {},
         success?: (publication: Publication) => void,

--- a/webapp-beta/routes/publication/components/publicationOverview/publicationOverview.component.ts
+++ b/webapp-beta/routes/publication/components/publicationOverview/publicationOverview.component.ts
@@ -60,7 +60,7 @@ class PublicationOverviewCtrl implements angular.IController {
             }).$promise;
         } else { // it's an old one
             const updatedIndex = this.publications.findIndex((pub) => pub.id === this.editing.id);
-            this.savePromise = this.editing.$update({}, (updated: Publication) => {
+            this.savePromise = this.editing.$updateMetadata({}, (updated: Publication) => {
                 this.publications[updatedIndex] = updated;
                 this.editPublication(updated);
                 this.yearOptions = this.createYearOptions();

--- a/webapp-beta/routes/publication/components/publicationOverview/publicationOverview.component.ts
+++ b/webapp-beta/routes/publication/components/publicationOverview/publicationOverview.component.ts
@@ -60,11 +60,11 @@ class PublicationOverviewCtrl implements angular.IController {
             }).$promise;
         } else { // it's an old one
             const updatedIndex = this.publications.findIndex((pub) => pub.id === this.editing.id);
-            this.savePromise = this.editing.$updateMetadata({}, (updated: Publication) => {
+            this.savePromise = this.publicationResource.updateMetadata({}, this.editing, (updated: Publication) => {
                 this.publications[updatedIndex] = updated;
                 this.editPublication(updated);
                 this.yearOptions = this.createYearOptions();
-            });
+            }).$promise;
         }
     }
 }

--- a/webapp/js/controllers/DispositionCtrl.js
+++ b/webapp/js/controllers/DispositionCtrl.js
@@ -146,7 +146,7 @@ angular.module('momusApp.controllers')
                     vm.pagesLookup[p.id] = p;
                     publication.pages.push(p);
                 });
-                pageOrder.order.splice(newPageAt, 0, ...pages.map(p => p.id));
+                pageOrder.order.splice(newPageAt, 0, ...pages.map(p => ({ id: p.id })));
                 vm.loading = false;
             });
         }

--- a/webapp/js/controllers/FrontPageCtrl.js
+++ b/webapp/js/controllers/FrontPageCtrl.js
@@ -72,7 +72,7 @@ angular.module('momusApp.controllers')
             Person.updateFavouritesection({section: vm.user.favouritesection.id});
             vm.favouriteSectionArticles = Article.search({}, {
                 section: vm.user.favouritesection.id,
-                page_number: 1,
+                page_number: 0,
                 page_size: 9,
             });
         }

--- a/webapp/js/controllers/PublicationCtrl.js
+++ b/webapp/js/controllers/PublicationCtrl.js
@@ -63,7 +63,7 @@ angular.module('momusApp.controllers')
                 })
             } else { // it's an old one
                 const updatedIndex = vm.publications.findIndex(pub => pub.id === vm.editing.id);
-                vm.editing.$update({}, (updated) => {
+                vm.editing.$updateMetadata({}, (updated) => {
                     vm.publications[updatedIndex] = updated;
                     editPublication(updated);
                     vm.isSaving = false;

--- a/webapp/js/resources/Publication.js
+++ b/webapp/js/resources/Publication.js
@@ -18,7 +18,7 @@
 
 angular.module('momusApp.resources')
     .factory('Publication', (momResource) => {
-        return momResource('/api/publications/:id',
+        return momResource('/api/publications/:id/:resource',
             {
                 id: '@id'
             },

--- a/webapp/js/resources/Publication.js
+++ b/webapp/js/resources/Publication.js
@@ -23,6 +23,7 @@ angular.module('momusApp.resources')
                 id: '@id'
             },
             {
+                updateMetadata: { method: 'PATCH', params: {resource: 'metadata'} },
                 active: { method: 'GET', params: {id: 'active'}, bypassInterceptor: true },
                 layoutStatuses: { method: 'GET', isArray: true, params: {id: 'layoutstatuses'}, cache: true, skipTransform: true}
             },


### PR DESCRIPTION
The new Spring jpa offers a better api for handling null when fetching by id, using optionals, so use that instead. Some refactoring on all the controllers and services, e.g. not use @responsebody since it is unnecessary.