### PR TITLE
MOM-265 Add separate table for person avatar

### DIFF
--- a/src/main/java/no/dusken/momus/controller/PersonController.java
+++ b/src/main/java/no/dusken/momus/controller/PersonController.java
@@ -78,7 +78,7 @@ public class PersonController {
     public void getPersonPhoto(@PathVariable("id") Long id, HttpServletResponse response) throws IOException, SQLException {
         Avatar avatar = avatarRepository.findOne(id);
 
-        if(avatar.getAvatar() == null) {
+        if(avatar == null) {
             throw new RestException("No photo found for user", 404);
         }
 

--- a/src/main/java/no/dusken/momus/controller/PersonController.java
+++ b/src/main/java/no/dusken/momus/controller/PersonController.java
@@ -19,8 +19,10 @@ package no.dusken.momus.controller;
 import com.google.api.client.util.IOUtils;
 import no.dusken.momus.authentication.UserDetailsService;
 import no.dusken.momus.exceptions.RestException;
+import no.dusken.momus.model.Avatar;
 import no.dusken.momus.model.Person;
 import no.dusken.momus.service.PersonService;
+import no.dusken.momus.service.repository.AvatarRepository;
 import no.dusken.momus.service.repository.PersonRepository;
 import no.dusken.momus.service.repository.SectionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,9 @@ public class PersonController {
 
     @Autowired
     private PersonRepository personRepository;
+
+    @Autowired
+    private AvatarRepository avatarRepository;
 
     @Autowired
     private UserDetailsService userDetailsService;
@@ -71,16 +76,16 @@ public class PersonController {
 
     @GetMapping("/{id}/photo")
     public void getPersonPhoto(@PathVariable("id") Long id, HttpServletResponse response) throws IOException, SQLException {
-        Person person = personRepository.findOne(id);
+        Avatar avatar = avatarRepository.findOne(id);
 
-        if(person.getPhoto() == null) {
+        if(avatar.getAvatar() == null) {
             throw new RestException("No photo found for user", 404);
         }
 
         response.addHeader("Content-Type", "image/jpeg");
 
         ServletOutputStream outStream = response.getOutputStream();
-        IOUtils.copy(person.getPhoto().getBinaryStream(), outStream);
+        IOUtils.copy(avatar.getAvatar().getBinaryStream(), outStream);
         outStream.flush();
         outStream.close();
     }

--- a/src/main/java/no/dusken/momus/ldap/LDAPAttributes.java
+++ b/src/main/java/no/dusken/momus/ldap/LDAPAttributes.java
@@ -17,7 +17,7 @@ public class LDAPAttributes {
     private static final String phoneNumberAttribute = "telephoneNumber";
     private static final String firstNameAttribute = "givenName";
     private static final String lastNameAttribute = "sn";
-    private static final String photoAttribute = "thumbnailPhoto";
+    private static final String avatarAttribute = "thumbnailPhoto";
     private static final String groupAttribute = "memberOf";
     private static final String[] nameAttributes = {"displayName", "name", "cn"};
 
@@ -37,13 +37,13 @@ public class LDAPAttributes {
         return getAttribute(attributes, phoneNumberAttribute);
     }
 
-    public static Blob getPhoto(Attributes attributes) throws NamingException {
-        Attribute photo = attributes.get(photoAttribute);
-        if(photo == null) {
+    public static Blob getAvatar(Attributes attributes) throws NamingException {
+        Attribute avatar = attributes.get(avatarAttribute);
+        if(avatar == null) {
             return null;
         }
         try {
-            return new SerialBlob((byte[]) photo.get());
+            return new SerialBlob((byte[]) avatar.get());
         } catch (SQLException e) {
             return null;
         }

--- a/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
+++ b/src/main/java/no/dusken/momus/ldap/LdapSyncer.java
@@ -20,8 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import no.dusken.momus.authorization.Role;
 import no.dusken.momus.ldap.PersonMapper.Status;
 import no.dusken.momus.model.Person;
+import no.dusken.momus.service.repository.AvatarRepository;
 import no.dusken.momus.service.repository.PersonRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.ldap.control.PagedResultsDirContextProcessor;
@@ -43,14 +43,20 @@ public class LdapSyncer {
 
     private final String USER_FILTER = "(&(objectClass=user)(!(objectClass=inetOrgPerson)))";
 
-    @Autowired
-    LdapTemplate ldapTemplate;
+    private final LdapTemplate ldapTemplate;
 
-    @Autowired
-    PersonRepository personRepository;
+    private final PersonRepository personRepository;
 
-    @Autowired
-    Environment env;
+    private final AvatarRepository avatarRepository;
+
+    private final Environment env;
+
+    public LdapSyncer (LdapTemplate ldapTemplate, PersonRepository personRepository, AvatarRepository avatarRepository, Environment env) {
+        this.ldapTemplate = ldapTemplate;
+        this.personRepository = personRepository;
+        this.avatarRepository = avatarRepository;
+        this.env = env;
+    }
 
     @Value("${ldap.syncEnabled}")
     private boolean enabled;
@@ -111,7 +117,7 @@ public class LdapSyncer {
         SearchControls ctrl = new SearchControls();
         ctrl.setSearchScope(SearchControls.SUBTREE_SCOPE);
 
-        PersonMapper personMapper = new PersonMapper(personRepository, active, groupToRole);
+        PersonMapper personMapper = new PersonMapper(personRepository, avatarRepository, active, groupToRole);
 
         List<Person> persons = new ArrayList<>();
 

--- a/src/main/java/no/dusken/momus/model/Avatar.java
+++ b/src/main/java/no/dusken/momus/model/Avatar.java
@@ -1,0 +1,32 @@
+package no.dusken.momus.model;
+
+import java.sql.Blob;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = {"id"})
+@ToString(of = {"id"})
+@Builder(toBuilder = true)
+public class Avatar {
+    @Id
+    private Long id;
+
+    @JsonIgnore
+    @Lob
+    private Blob avatar;
+}

--- a/src/main/java/no/dusken/momus/model/Person.java
+++ b/src/main/java/no/dusken/momus/model/Person.java
@@ -24,7 +24,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
-import java.sql.Blob;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -55,10 +54,6 @@ public class Person implements UserDetails {
 
     @ManyToOne(fetch = FetchType.EAGER)
     private Section favouritesection;
-
-    @JsonIgnore
-    @Lob
-    private Blob photo;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/no/dusken/momus/service/repository/AvatarRepository.java
+++ b/src/main/java/no/dusken/momus/service/repository/AvatarRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Studentmediene i Trondheim AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package no.dusken.momus.service.repository;
+
+import no.dusken.momus.model.Avatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+}

--- a/src/main/resources/db-changelog.xml
+++ b/src/main/resources/db-changelog.xml
@@ -812,4 +812,27 @@
         <addForeignKeyConstraint baseColumnNames="article_id" baseTableName="article_graphic" constraintName="FK_article_graphic_article" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="article"/>
         <addForeignKeyConstraint baseColumnNames="graphics_id" baseTableName="article_graphic" constraintName="FK_article_graphic_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="person"/>
     </changeSet>
+
+    <changeSet id="46_avatar_table" author="Eivind">
+        <dropColumn tableName="person" columnName="photo" />
+
+        <createTable tableName="avatar">
+            <column name="id" type="BIGINT">
+                <constraints primaryKey="true" />
+            </column>
+            <column name="avatar" type="BLOB" />
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseColumnNames="id"
+            baseTableName="avatar"
+            constraintName="FK_avatar_person"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            onUpdate="CASCADE"
+            referencedColumnNames="id"
+            referencedTableName="person"
+        />
+    </changeSet>
 </databaseChangeLog>

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -103,7 +103,7 @@ angular.module('momusApp', [
                                 {}, 
                                 {
                                     section: loggedInPerson.favouritesection.id,
-                                    page_number: 1,
+                                    page_number: 0,
                                     page_size: 9,
                                 }).$promise :
                             [];


### PR DESCRIPTION
Having a blob in the user table creates problem when running update queries. This commit puts the avatar in its own table instead.